### PR TITLE
store photos in private bucket, add GET submissions and id

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,38 +17,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from routes import leaderboard, submissions, tasks  # noqa: E402
+from routes import leaderboard, submissions, tasks, teams  # noqa: E402
 
 app.include_router(submissions.router, prefix="/submissions", tags=["submissions"])
 app.include_router(tasks.router, prefix="/tasks", tags=["tasks"])
 app.include_router(leaderboard.router, prefix="/leaderboard", tags=["leaderboard"])
+app.include_router(teams.router, prefix="/teams", tags=["teams"])
 
 
 @app.get("/health")
 def health():
     return {"status": "ok", "env": os.getenv("ENV", "dev")}
-
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv
-import os
-
-load_dotenv()
-
-app = FastAPI(title="Sapsut API")
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-from routes import submissions, tasks, leaderboard
-app.include_router(submissions.router, prefix="/submissions", tags=["submissions"])
-app.include_router(tasks.router, prefix="/tasks", tags=["tasks"])
-app.include_router(leaderboard.router, prefix="/leaderboard", tags=["leaderboard"])
-
-@app.get("/health")
-def health():
-    return {"status": "ok"}

--- a/backend/routes/submissions.py
+++ b/backend/routes/submissions.py
@@ -1,13 +1,84 @@
 import uuid
 
 import anyio
-from fastapi import APIRouter, BackgroundTasks, File, Form, UploadFile
+from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Query, UploadFile
+from typing import Any, Dict, Optional
 
 from services import get_supabase
 from services.scoring import score_submission
 from services.storage import storage_bucket
 
 router = APIRouter()
+
+
+def _extract_signed_url(resp: Any) -> Optional[str]:
+    if not resp:
+        return None
+    if isinstance(resp, str):
+        return resp
+    if isinstance(resp, dict):
+        for k in ("signedURL", "signed_url", "signedUrl", "url"):
+            v = resp.get(k)
+            if isinstance(v, str) and v:
+                return v
+        data = resp.get("data")
+        if isinstance(data, dict):
+            for k in ("signedURL", "signed_url", "signedUrl", "url"):
+                v = data.get(k)
+                if isinstance(v, str) and v:
+                    return v
+    return None
+
+
+@router.get("/{id}")
+async def get_submission(id: str) -> Dict[str, Any]:
+    supabase = get_supabase()
+    rows = (
+        supabase.table("submissions")
+        .select(
+            "id,task_id,team_id,text_answer,photo_url,status,score,confidence,rationale,gpt4o_description,ai_result,created_at"
+        )
+        .eq("id", id)
+        .limit(1)
+        .execute()
+        .data
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    submission: Dict[str, Any] = rows[0]
+
+    photo_path = submission.get("photo_url")
+    if photo_path:
+        try:
+            signed = await anyio.to_thread.run_sync(
+                lambda: supabase.storage.from_(storage_bucket()).create_signed_url(photo_path, 600)
+            )
+            signed_url = _extract_signed_url(signed)
+            if signed_url:
+                submission["photo_signed_url"] = signed_url
+        except Exception:
+            pass
+
+    return submission
+
+
+@router.get("/")
+def list_submissions(
+    team_id: str = Query(...),
+    task_id: Optional[str] = Query(None),
+) -> Any:
+    supabase = get_supabase()
+    q = (
+        supabase.table("submissions")
+        .select(
+            "id,task_id,team_id,text_answer,photo_url,status,score,confidence,rationale,gpt4o_description,ai_result,created_at"
+        )
+        .eq("team_id", team_id)
+        .order("created_at", desc=True)
+    )
+    if task_id:
+        q = q.eq("task_id", task_id)
+    return q.execute().data or []
 
 
 @router.post("/")
@@ -61,7 +132,7 @@ async def create_submission(
         photo_bytes = await photo.read()
         content_type = (photo.content_type or "application/octet-stream").strip()
         ext = (content_type.split("/")[-1] if "/" in content_type else "bin") or "bin"
-        photo_path = f"submissions/{submission_id}.{ext}"
+        photo_path = f"{team_id}/{task_id}/{submission_id}.{ext}"
         try:
             # Supabase Storage upload is synchronous; offload to worker thread.
             await anyio.to_thread.run_sync(

--- a/backend/services/storage.py
+++ b/backend/services/storage.py
@@ -7,5 +7,5 @@ def storage_bucket() -> str:
     """
     Shared Supabase Storage bucket selector for uploads/downloads.
     """
-    return os.getenv("SUPABASE_STORAGE_BUCKET", "submissions").strip() or "submissions"
+    return os.getenv("SUPABASE_STORAGE_BUCKET", "submission-photos").strip() or "submission-photos"
 

--- a/backend/tests/test_submissions_routes.py
+++ b/backend/tests/test_submissions_routes.py
@@ -31,6 +31,7 @@ class _TableQuery:
         self._order = None
         self._insert_payloads = []
         self._select_cols = "*"
+        self._single = False
 
     def select(self, cols="*"):
         self._select_cols = cols
@@ -46,6 +47,10 @@ class _TableQuery:
 
     def order(self, k, desc=False):
         self._order = (k, bool(desc))
+        return self
+
+    def single(self):
+        self._single = True
         return self
 
     def insert(self, payload):
@@ -65,6 +70,8 @@ class _TableQuery:
             rows.sort(key=lambda r: r.get(key), reverse=desc)
         if self._limit is not None:
             rows = rows[: self._limit]
+        if self._single:
+            return _Resp(rows[0] if rows else None)
         return _Resp(rows)
 
 
@@ -117,6 +124,7 @@ def app_and_client(monkeypatch):
     fake.db["tasks"].append({"id": "task1", "allow_multiple_submissions": True})
 
     monkeypatch.setattr(submissions_routes, "get_supabase", lambda: fake)
+    monkeypatch.setattr(submissions_routes, "score_submission", lambda *a, **kw: None)
 
     app = FastAPI()
     app.include_router(submissions_routes.router, prefix="/submissions")

--- a/backend/tests/test_submissions_routes.py
+++ b/backend/tests/test_submissions_routes.py
@@ -1,0 +1,249 @@
+import uuid as _uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+try:
+    import python_multipart as _pm  # noqa: F401
+
+    _HAVE_MULTIPART = True
+except Exception:
+    try:
+        import multipart as _mp  # type: ignore  # noqa: F401
+
+        _HAVE_MULTIPART = True
+    except Exception:
+        _HAVE_MULTIPART = False
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _TableQuery:
+    def __init__(self, db, name):
+        self._db = db
+        self._name = name
+        self._filters = {}
+        self._limit = None
+        self._order = None
+        self._insert_payloads = []
+        self._select_cols = "*"
+
+    def select(self, cols="*"):
+        self._select_cols = cols
+        return self
+
+    def eq(self, k, v):
+        self._filters[k] = v
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def order(self, k, desc=False):
+        self._order = (k, bool(desc))
+        return self
+
+    def insert(self, payload):
+        self._insert_payloads.append(payload)
+        if isinstance(payload, dict):
+            self._db.setdefault(self._name, []).append(payload)
+        elif isinstance(payload, list):
+            self._db.setdefault(self._name, []).extend(payload)
+        return self
+
+    def execute(self):
+        rows = list(self._db.get(self._name, []))
+        for k, v in self._filters.items():
+            rows = [r for r in rows if r.get(k) == v]
+        if self._order:
+            key, desc = self._order
+            rows.sort(key=lambda r: r.get(key), reverse=desc)
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return _Resp(rows)
+
+
+class _StorageBucket:
+    def __init__(self, parent):
+        self._parent = parent
+
+    def upload(self, path, data, file_options=None):
+        if self._parent.fail_upload:
+            raise RuntimeError("boom")
+        self._parent.upload_calls.append((path, data, file_options))
+        return {"path": path}
+
+    def create_signed_url(self, path, expires_in):
+        self._parent.sign_calls.append((path, expires_in))
+        return {"signedURL": f"https://signed.example/{path}?exp={expires_in}"}
+
+
+class _Storage:
+    def __init__(self, parent):
+        self._parent = parent
+
+    def from_(self, bucket):
+        self._parent.bucket_calls.append(bucket)
+        return _StorageBucket(self._parent)
+
+
+class _FakeSupabase:
+    def __init__(self):
+        self.db = {"submissions": [], "tasks": []}
+        self.storage = _Storage(self)
+        self.fail_upload = False
+        self.upload_calls = []
+        self.sign_calls = []
+        self.bucket_calls = []
+
+    def table(self, name):
+        return _TableQuery(self.db, name)
+
+
+@pytest.fixture()
+def app_and_client(monkeypatch):
+    if not _HAVE_MULTIPART:
+        pytest.skip('FastAPI Form/File routes require "python-multipart"')
+
+    from routes import submissions as submissions_routes
+
+    fake = _FakeSupabase()
+    # Default: allow multiple to avoid the existing-submission branch.
+    fake.db["tasks"].append({"id": "task1", "allow_multiple_submissions": True})
+
+    monkeypatch.setattr(submissions_routes, "get_supabase", lambda: fake)
+
+    app = FastAPI()
+    app.include_router(submissions_routes.router, prefix="/submissions")
+    return fake, TestClient(app)
+
+
+def test_post_submission_photo_upload_path_format(app_and_client, monkeypatch):
+    fake, client = app_and_client
+
+    fixed_id = _uuid.UUID("00000000-0000-0000-0000-000000000123")
+    from routes import submissions as submissions_routes
+
+    monkeypatch.setattr(submissions_routes.uuid, "uuid4", lambda: fixed_id)
+
+    resp = client.post(
+        "/submissions/",
+        data={"task_id": "task1", "team_id": "teamA", "text_answer": ""},
+        files={"photo": ("x.png", b"pngbytes", "image/png")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["submission_id"] == str(fixed_id)
+
+    assert fake.upload_calls, "expected storage upload to be called"
+    uploaded_path, uploaded_bytes, file_options = fake.upload_calls[0]
+    assert uploaded_path == f"teamA/task1/{fixed_id}.png"
+    assert uploaded_bytes == b"pngbytes"
+    assert file_options["content-type"] == "image/png"
+
+    assert fake.db["submissions"], "expected submission to be inserted"
+    inserted = fake.db["submissions"][0]
+    assert inserted["photo_url"] == uploaded_path
+    assert inserted["status"] == "pending"
+
+
+def test_post_submission_upload_failure_sets_error_status(app_and_client, monkeypatch):
+    fake, client = app_and_client
+    fake.fail_upload = True
+
+    fixed_id = _uuid.UUID("00000000-0000-0000-0000-000000000999")
+    from routes import submissions as submissions_routes
+
+    monkeypatch.setattr(submissions_routes.uuid, "uuid4", lambda: fixed_id)
+
+    resp = client.post(
+        "/submissions/",
+        data={"task_id": "task1", "team_id": "teamA", "text_answer": "hi"},
+        files={"photo": ("x.jpg", b"jpgbytes", "image/jpeg")},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+    assert fake.db["submissions"], "expected error submission row to be inserted"
+    inserted = fake.db["submissions"][0]
+    assert inserted["id"] == str(fixed_id)
+    assert inserted["status"] == "error"
+    assert inserted["photo_url"] is None
+
+
+def test_get_submission_by_id_includes_signed_url_when_photo_exists(app_and_client):
+    fake, client = app_and_client
+    fake.db["submissions"].append(
+        {
+            "id": "sub1",
+            "task_id": "task1",
+            "team_id": "teamA",
+            "text_answer": "",
+            "photo_url": "teamA/task1/sub1.png",
+            "status": "approved",
+            "score": 3,
+            "confidence": 0.95,
+            "rationale": "ok",
+            "gpt4o_description": "desc",
+            "ai_result": {"mode": "llm"},
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+    )
+
+    resp = client.get("/submissions/sub1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "sub1"
+    assert data["photo_url"] == "teamA/task1/sub1.png"
+    assert data["photo_signed_url"].startswith("https://signed.example/")
+    assert fake.sign_calls == [("teamA/task1/sub1.png", 600)]
+
+
+def test_list_submissions_omits_signed_urls(app_and_client):
+    fake, client = app_and_client
+    fake.db["submissions"].extend(
+        [
+            {
+                "id": "sub1",
+                "task_id": "task1",
+                "team_id": "teamA",
+                "text_answer": "",
+                "photo_url": "teamA/task1/sub1.png",
+                "status": "approved",
+                "score": 3,
+                "confidence": 0.95,
+                "rationale": "ok",
+                "gpt4o_description": "desc",
+                "ai_result": {"mode": "llm"},
+                "created_at": "2026-01-02T00:00:00Z",
+            },
+            {
+                "id": "sub2",
+                "task_id": "task2",
+                "team_id": "teamA",
+                "text_answer": "hi",
+                "photo_url": None,
+                "status": "pending",
+                "score": None,
+                "confidence": None,
+                "rationale": None,
+                "gpt4o_description": None,
+                "ai_result": None,
+                "created_at": "2026-01-03T00:00:00Z",
+            },
+        ]
+    )
+
+    resp = client.get("/submissions/?team_id=teamA")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert isinstance(rows, list)
+    assert [r["id"] for r in rows] == ["sub2", "sub1"]
+    assert all("photo_signed_url" not in r for r in rows)
+

--- a/backend/tests/test_teams_routes.py
+++ b/backend/tests/test_teams_routes.py
@@ -1,0 +1,144 @@
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    import python_multipart as _pm  # noqa: F401
+
+    _HAVE_MULTIPART = True
+except Exception:
+    try:
+        import multipart as _mp  # type: ignore  # noqa: F401
+
+        _HAVE_MULTIPART = True
+    except Exception:
+        _HAVE_MULTIPART = False
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _TeamsTable:
+    def __init__(self, store, *, fail_first_insert=False):
+        self._store = store
+        self._filters = {}
+        self._maybe_single = False
+        self._select = "*"
+        self._pending_insert = None
+        self._fail_first_insert = fail_first_insert
+        self._insert_calls = 0
+
+    def select(self, cols="*"):
+        self._select = cols
+        return self
+
+    def insert(self, payload):
+        self._pending_insert = payload
+        return self
+
+    def eq(self, k, v):
+        self._filters[k] = v
+        return self
+
+    def maybe_single(self):
+        self._maybe_single = True
+        return self
+
+    def execute(self):
+        if self._pending_insert is not None:
+            self._insert_calls += 1
+            if self._fail_first_insert and self._insert_calls == 1:
+                raise Exception(
+                    'duplicate key value violates unique constraint "teams_invite_code_key"'
+                )
+
+            tid = str(uuid.uuid4())
+            row = {
+                "id": tid,
+                "name": self._pending_insert["name"],
+                "invite_code": self._pending_insert["invite_code"],
+                "total_score": 0,
+            }
+            self._store["teams_by_id"][tid] = row
+            self._store["teams_by_invite"][row["invite_code"]] = row
+            return _Resp([{"id": tid, "invite_code": row["invite_code"]}])
+
+        if "id" in self._filters:
+            row = self._store["teams_by_id"].get(self._filters["id"])
+            return _Resp(row if row is not None else None)
+
+        if "invite_code" in self._filters:
+            row = self._store["teams_by_invite"].get(self._filters["invite_code"])
+            return _Resp(row if row is not None else None)
+
+        raise AssertionError("Unexpected query in fake teams table")
+
+
+class _FakeSupabase:
+    def __init__(self, *, fail_first_insert=False):
+        self._store = {"teams_by_id": {}, "teams_by_invite": {}}
+        self._fail_first_insert = fail_first_insert
+        self.teams_table = _TeamsTable(self._store, fail_first_insert=fail_first_insert)
+
+    def table(self, name):
+        assert name == "teams"
+        return self.teams_table
+
+
+def _make_client(monkeypatch, fake):
+    if not _HAVE_MULTIPART:
+        pytest.skip('FastAPI Form/File routes require "python-multipart"')
+
+    import main
+    import routes.teams as teams_routes
+
+    monkeypatch.setattr(teams_routes, "get_supabase", lambda: fake)
+    return TestClient(main.app)
+
+
+def test_post_teams_creates_team_and_returns_id_and_invite_code(monkeypatch):
+    client = _make_client(monkeypatch, _FakeSupabase())
+    res = client.post("/teams/", json={"name": "Team A"})
+    assert res.status_code == 200
+    body = res.json()
+    assert "id" in body
+    assert "invite_code" in body
+
+
+def test_get_teams_by_id_includes_total_score(monkeypatch):
+    fake = _FakeSupabase()
+    client = _make_client(monkeypatch, fake)
+
+    created = client.post("/teams/", json={"name": "Team B"}).json()
+    team_id = created["id"]
+
+    res = client.get(f"/teams/{team_id}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["id"] == team_id
+    assert body["total_score"] == 0
+
+
+def test_get_teams_by_invite_code_returns_team_or_404(monkeypatch):
+    client = _make_client(monkeypatch, _FakeSupabase())
+    created = client.post("/teams/", json={"name": "Team C"}).json()
+    invite_code = created["invite_code"]
+
+    res = client.get("/teams/", params={"invite_code": invite_code})
+    assert res.status_code == 200
+    assert res.json()["invite_code"] == invite_code
+
+    res2 = client.get("/teams/", params={"invite_code": "DOESNOTEXIST"})
+    assert res2.status_code == 404
+
+
+def test_post_teams_retries_on_invite_code_unique_violation(monkeypatch):
+    client = _make_client(monkeypatch, _FakeSupabase(fail_first_insert=True))
+    res = client.post("/teams/", json={"name": "Team D"})
+    assert res.status_code == 200
+    body = res.json()
+    assert "id" in body and "invite_code" in body
+


### PR DESCRIPTION
# What
submissions.py — GET /{id} and GET / read endpoints with signed URL injection on detail, team_id/task_id filtering on list; photo path scoped to {team_id}/{task_id}/{submission_id}.{ext}, upload offloaded to thread, failure now fatal to the request 
storage.py — default bucket renamed to submission-photos
tests/test_submissions_routes.py — 4 tests: path format, upload failure → error status, signed URL on GET /{id}, signed URLs absent on list

# Why
Submissions were write-only with no retrieval path. The organizer review dashboard and team submission history both need to read submissions back, including photo access via short-lived signed URLs rather than public paths.