### PR TITLE
add teams endpoints

### DIFF
--- a/backend/routes/teams.py
+++ b/backend/routes/teams.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import secrets
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from services import get_supabase
+
+router = APIRouter()
+
+_INVITE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"  # no 0/1/I/L/O
+
+
+def _generate_invite_code(length: int = 8) -> str:
+    return "".join(secrets.choice(_INVITE_ALPHABET) for _ in range(length))
+
+
+def _is_invite_code_unique_violation(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "duplicate" in msg and "invite" in msg and "code" in msg
+
+
+class TeamCreateIn(BaseModel):
+    name: str = Field(min_length=1)
+
+
+@router.post("/")
+def create_team(payload: TeamCreateIn) -> Any:
+    supabase = get_supabase()
+
+    last_exc: Optional[Exception] = None
+    for _ in range(5):
+        invite_code = _generate_invite_code()
+        try:
+            res = (
+                supabase.table("teams")
+                .insert({"name": payload.name, "invite_code": invite_code})
+                .execute()
+            )
+            data = res.data or []
+            row = data[0] if isinstance(data, list) and data else data
+            if not row or "id" not in row or "invite_code" not in row:
+                raise HTTPException(status_code=500, detail="Failed to create team")
+            return {"id": row["id"], "invite_code": row["invite_code"]}
+        except Exception as e:
+            last_exc = e
+            if _is_invite_code_unique_violation(e):
+                continue
+            raise HTTPException(status_code=400, detail=str(e))
+
+    raise HTTPException(
+        status_code=500,
+        detail=f"Failed to generate unique invite_code: {last_exc}",
+    )
+
+
+@router.get("/{id}")
+def get_team_by_id(id: str) -> Any:
+    supabase = get_supabase()
+    res = supabase.table("teams").select("*").eq("id", id).maybe_single().execute()
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return res.data
+
+
+@router.get("/")
+def get_team_by_invite_code(invite_code: str = Query(...)) -> Any:
+    supabase = get_supabase()
+    res = (
+        supabase.table("teams")
+        .select("*")
+        .eq("invite_code", invite_code)
+        .maybe_single()
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Team not found")
+    return res.data
+

--- a/backend/routes/teams.py
+++ b/backend/routes/teams.py
@@ -44,6 +44,8 @@ def create_team(payload: TeamCreateIn) -> Any:
             if not row or "id" not in row or "invite_code" not in row:
                 raise HTTPException(status_code=500, detail="Failed to create team")
             return {"id": row["id"], "invite_code": row["invite_code"]}
+        except HTTPException:
+            raise
         except Exception as e:
             last_exc = e
             if _is_invite_code_unique_violation(e):

--- a/backend/tests/test_teams_routes.py
+++ b/backend/tests/test_teams_routes.py
@@ -1,6 +1,19 @@
 import uuid
 
+import pytest
 from fastapi.testclient import TestClient
+
+try:
+    import python_multipart as _pm  # noqa: F401
+
+    _HAVE_MULTIPART = True
+except Exception:
+    try:
+        import multipart as _mp  # type: ignore  # noqa: F401
+
+        _HAVE_MULTIPART = True
+    except Exception:
+        _HAVE_MULTIPART = False
 
 
 class _Resp:
@@ -71,6 +84,9 @@ class _FakeSupabase:
 
 
 def _make_client(monkeypatch, fake):
+    if not _HAVE_MULTIPART:
+        pytest.skip('FastAPI Form/File routes require "python-multipart"')
+
     import main
     import routes.teams as teams_routes
 

--- a/backend/tests/test_teams_routes.py
+++ b/backend/tests/test_teams_routes.py
@@ -1,19 +1,6 @@
 import uuid
 
-import pytest
 from fastapi.testclient import TestClient
-
-try:
-    import python_multipart as _pm  # noqa: F401
-
-    _HAVE_MULTIPART = True
-except Exception:
-    try:
-        import multipart as _mp  # type: ignore  # noqa: F401
-
-        _HAVE_MULTIPART = True
-    except Exception:
-        _HAVE_MULTIPART = False
 
 
 class _Resp:
@@ -22,17 +9,14 @@ class _Resp:
 
 
 class _TeamsTable:
-    def __init__(self, store, *, fail_first_insert=False):
+    def __init__(self, store, *, fail_first_insert: bool = False):
         self._store = store
         self._filters = {}
-        self._maybe_single = False
-        self._select = "*"
         self._pending_insert = None
         self._fail_first_insert = fail_first_insert
         self._insert_calls = 0
 
-    def select(self, cols="*"):
-        self._select = cols
+    def select(self, cols: str = "*"):
         return self
 
     def insert(self, payload):
@@ -44,7 +28,6 @@ class _TeamsTable:
         return self
 
     def maybe_single(self):
-        self._maybe_single = True
         return self
 
     def execute(self):
@@ -78,20 +61,16 @@ class _TeamsTable:
 
 
 class _FakeSupabase:
-    def __init__(self, *, fail_first_insert=False):
+    def __init__(self, *, fail_first_insert: bool = False):
         self._store = {"teams_by_id": {}, "teams_by_invite": {}}
-        self._fail_first_insert = fail_first_insert
-        self.teams_table = _TeamsTable(self._store, fail_first_insert=fail_first_insert)
+        self._teams = _TeamsTable(self._store, fail_first_insert=fail_first_insert)
 
     def table(self, name):
         assert name == "teams"
-        return self.teams_table
+        return self._teams
 
 
 def _make_client(monkeypatch, fake):
-    if not _HAVE_MULTIPART:
-        pytest.skip('FastAPI Form/File routes require "python-multipart"')
-
     import main
     import routes.teams as teams_routes
 
@@ -109,30 +88,26 @@ def test_post_teams_creates_team_and_returns_id_and_invite_code(monkeypatch):
 
 
 def test_get_teams_by_id_includes_total_score(monkeypatch):
-    fake = _FakeSupabase()
-    client = _make_client(monkeypatch, fake)
-
+    client = _make_client(monkeypatch, _FakeSupabase())
     created = client.post("/teams/", json={"name": "Team B"}).json()
-    team_id = created["id"]
 
-    res = client.get(f"/teams/{team_id}")
+    res = client.get(f"/teams/{created['id']}")
     assert res.status_code == 200
     body = res.json()
-    assert body["id"] == team_id
+    assert body["id"] == created["id"]
     assert body["total_score"] == 0
 
 
 def test_get_teams_by_invite_code_returns_team_or_404(monkeypatch):
     client = _make_client(monkeypatch, _FakeSupabase())
     created = client.post("/teams/", json={"name": "Team C"}).json()
-    invite_code = created["invite_code"]
 
-    res = client.get("/teams/", params={"invite_code": invite_code})
-    assert res.status_code == 200
-    assert res.json()["invite_code"] == invite_code
+    ok = client.get("/teams/", params={"invite_code": created["invite_code"]})
+    assert ok.status_code == 200
+    assert ok.json()["invite_code"] == created["invite_code"]
 
-    res2 = client.get("/teams/", params={"invite_code": "DOESNOTEXIST"})
-    assert res2.status_code == 404
+    missing = client.get("/teams/", params={"invite_code": "DOESNOTEXIST"})
+    assert missing.status_code == 404
 
 
 def test_post_teams_retries_on_invite_code_unique_violation(monkeypatch):
@@ -141,4 +116,3 @@ def test_post_teams_retries_on_invite_code_unique_violation(monkeypatch):
     assert res.status_code == 200
     body = res.json()
     assert "id" in body and "invite_code" in body
-


### PR DESCRIPTION
# What
teams.py — POST /teams/ creates a team with a 8-char invite code (unambiguous alphabet, up to 5 retries on unique violation); GET /{id} by UUID; GET /?invite_code= for team join lookup
main.py — registers teams router, removes duplicate app/middleware definition leftover from earlier scaffold
tests/test_teams_routes.py — 4 tests: create returns id + invite code, GET by id includes total_score, GET by invite code returns 404 on miss, retry logic on unique constraint violation

# Why
Frontend needs a team identity before any submission can be created as team_id is required on every POST /submissions/. Invite codes give teams a join flow without auth; collision retry ensures code generation doesn't fail silently under load.