### PR TITLE
 add role-gating via X-Organizer-Code header and organizer endpoints

### DIFF
--- a/backend/auth/__init__.py
+++ b/backend/auth/__init__.py
@@ -1,4 +1,2 @@
 from __future__ import annotations
 
-from __future__ import annotations
-

--- a/backend/auth/organizer.py
+++ b/backend/auth/organizer.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+
+from fastapi import Header, HTTPException
+from typing import Optional
+
+
+def require_organizer(
+    x_organizer_code: Optional[str] = Header(default=None, alias="X-Organizer-Code"),
+) -> None:
+    expected = (os.getenv("ORGANIZER_DEMO_CODE") or "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=500,
+            detail="Organizer access is not configured (missing ORGANIZER_DEMO_CODE).",
+        )
+
+    received = (x_organizer_code or "").strip()
+    if received != expected:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing X-Organizer-Code for organizer access.",
+        )
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,12 +17,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from routes import leaderboard, submissions, tasks, teams  # noqa: E402
+from routes import leaderboard, organizer, submissions, tasks, teams  # noqa: E402
 
 app.include_router(submissions.router, prefix="/submissions", tags=["submissions"])
 app.include_router(tasks.router, prefix="/tasks", tags=["tasks"])
 app.include_router(leaderboard.router, prefix="/leaderboard", tags=["leaderboard"])
 app.include_router(teams.router, prefix="/teams", tags=["teams"])
+app.include_router(organizer.router, prefix="/organizer", tags=["organizer"])
 
 
 @app.get("/health")

--- a/backend/routes/organizer.py
+++ b/backend/routes/organizer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from auth.organizer import require_organizer
+from services import get_supabase
+from services.scoring import score_submission
+
+router = APIRouter(dependencies=[Depends(require_organizer)])
+
+
+@router.get("/review-queue")
+def list_review_queue() -> Any:
+    supabase = get_supabase()
+    # Keep it lightweight: return raw queue rows ordered newest first.
+    return (
+        supabase.table("review_queue")
+        .select("*")
+        .order("created_at", desc=True)
+        .execute()
+        .data
+        or []
+    )
+
+
+@router.post("/submissions/{submission_id}/rescore")
+def rescore_submission(submission_id: str, background_tasks: BackgroundTasks) -> Dict[str, Any]:
+    supabase = get_supabase()
+    row = (
+        supabase.table("submissions")
+        .select("id,task_id,team_id,text_answer,photo_url,status")
+        .eq("id", submission_id)
+        .maybe_single()
+        .execute()
+        .data
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    background_tasks.add_task(
+        score_submission,
+        row["id"],
+        row["task_id"],
+        row["team_id"],
+        row.get("text_answer") or "",
+        row.get("photo_url"),
+    )
+    return {"status": "queued", "submission_id": submission_id}
+
+
+class CriteriaIn(BaseModel):
+    criteria_type: Literal["exact", "rubric", "other"] = Field(default="exact")
+    value: str = Field(min_length=1)
+
+
+class CriteriaUpdateIn(BaseModel):
+    criteria: List[CriteriaIn]
+
+
+@router.put("/tasks/{task_id}/criteria")
+def replace_task_criteria(task_id: str, payload: CriteriaUpdateIn) -> Dict[str, Any]:
+    supabase = get_supabase()
+
+    # Replace semantics: wipe then insert.
+    try:
+        supabase.table("task_criteria").delete().eq("task_id", task_id).execute()
+    except Exception:
+        # If delete isn't supported / table missing, surface a useful error.
+        raise HTTPException(status_code=400, detail="Failed to clear existing criteria for task")
+
+    rows: List[Dict[str, Any]] = [
+        {"task_id": task_id, "criteria_type": c.criteria_type, "value": c.value} for c in payload.criteria
+    ]
+    try:
+        inserted = supabase.table("task_criteria").insert(rows).execute().data or []
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {"task_id": task_id, "inserted": inserted}
+

--- a/backend/routes/organizer.py
+++ b/backend/routes/organizer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field

--- a/backend/tests/test_organizer_gating.py
+++ b/backend/tests/test_organizer_gating.py
@@ -1,0 +1,112 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Query:
+    def __init__(self, db, name):
+        self._db = db
+        self._name = name
+        self._filters = {}
+        self._order = None
+        self._single = False
+
+    def select(self, _cols="*"):
+        return self
+
+    def eq(self, k, v):
+        self._filters[k] = v
+        return self
+
+    def order(self, k, desc=False):
+        self._order = (k, bool(desc))
+        return self
+
+    def maybe_single(self):
+        self._single = True
+        return self
+
+    def execute(self):
+        rows = list(self._db.get(self._name, []))
+        for k, v in self._filters.items():
+            rows = [r for r in rows if r.get(k) == v]
+        if self._order:
+            key, desc = self._order
+            rows.sort(key=lambda r: r.get(key), reverse=desc)
+        if self._single:
+            return _Resp(rows[0] if rows else None)
+        return _Resp(rows)
+
+
+class _FakeSupabase:
+    def __init__(self):
+        self.db = {
+            "review_queue": [{"id": "rq1", "created_at": "2026-01-01T00:00:00Z"}],
+            "submissions": [
+                {
+                    "id": "sub1",
+                    "task_id": "task1",
+                    "team_id": "team1",
+                    "text_answer": "hi",
+                    "photo_url": None,
+                    "status": "flagged",
+                }
+            ],
+            "tasks": [{"id": "task1", "title": "T", "type": "text", "max_points": 5}],
+        }
+
+    def table(self, name):
+        return _Query(self.db, name)
+
+
+@pytest.fixture()
+def app_client(monkeypatch):
+    from routes import organizer as organizer_routes
+    from routes import tasks as tasks_routes
+
+    fake = _FakeSupabase()
+    monkeypatch.setattr(organizer_routes, "get_supabase", lambda: fake)
+    monkeypatch.setattr(tasks_routes, "get_supabase", lambda: fake)
+    monkeypatch.setattr(organizer_routes, "score_submission", lambda *a, **kw: None)
+
+    app = FastAPI()
+    app.include_router(organizer_routes.router, prefix="/organizer")
+    app.include_router(tasks_routes.router, prefix="/tasks")
+    return TestClient(app)
+
+
+def test_organizer_endpoints_require_header(monkeypatch, app_client):
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    resp = app_client.get("/organizer/review-queue")
+    assert resp.status_code == 401
+    assert "X-Organizer-Code" in resp.json()["detail"]
+
+
+def test_organizer_endpoints_reject_mismatch(monkeypatch, app_client):
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    resp = app_client.get("/organizer/review-queue", headers={"X-Organizer-Code": "nope"})
+    assert resp.status_code == 401
+    assert "Invalid" in resp.json()["detail"]
+
+
+def test_organizer_endpoints_allow_match(monkeypatch, app_client):
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    resp = app_client.get("/organizer/review-queue", headers={"X-Organizer-Code": "secret"})
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+def test_non_organizer_endpoints_unaffected(monkeypatch, app_client):
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    resp = app_client.get("/tasks/")
+    assert resp.status_code == 200
+


### PR DESCRIPTION
# What
Organizer actions are now protected behind an X-Organizer-Code header checked against ORGANIZER_DEMO_CODE from the environment. Missing or mismatched header returns 401; unconfigured env var returns 500. Three organizer endpoints live under /organizer: review queue, submission rescore, and task criteria edit. 

# Why
The review dashboard is organizer-only as this is the view for submissions and scoring criteria. This is a light gate that enforces the boundary between different without requiring full auth.