### PR TITLE
added organizer rescore endpoint with force flag and delta scoring

### DIFF
--- a/backend/routes/organizer.py
+++ b/backend/routes/organizer.py
@@ -26,12 +26,20 @@ def list_review_queue() -> Any:
     )
 
 
+class RescoreIn(BaseModel):
+    force: bool = False
+
+
 @router.post("/submissions/{submission_id}/rescore")
-def rescore_submission(submission_id: str, background_tasks: BackgroundTasks) -> Dict[str, Any]:
+def rescore_submission(
+    submission_id: str,
+    payload: RescoreIn,
+    background_tasks: BackgroundTasks,
+) -> Dict[str, Any]:
     supabase = get_supabase()
     row = (
         supabase.table("submissions")
-        .select("id,task_id,team_id,text_answer,photo_url,status")
+        .select("id,task_id,team_id,text_answer,photo_url,status,score,rationale")
         .eq("id", submission_id)
         .maybe_single()
         .execute()
@@ -40,6 +48,24 @@ def rescore_submission(submission_id: str, background_tasks: BackgroundTasks) ->
     if not row:
         raise HTTPException(status_code=404, detail="Submission not found")
 
+    terminal_statuses = {"auto_approved", "reviewed"}
+    if (row.get("status") in terminal_statuses) and (not payload.force):
+        raise HTTPException(
+            status_code=400,
+            detail="Submission is already in a terminal state; set force=true to override.",
+        )
+
+    try:
+        supabase.table("review_queue").insert(
+            {
+                "submission_id": row["id"],
+                "suggested_score": int(row.get("score") or 0),
+                "claude_rationale": (row.get("rationale") or "Rescore requested").strip() or "Rescore requested",
+            }
+        ).execute()
+    except Exception:
+        pass
+
     background_tasks.add_task(
         score_submission,
         row["id"],
@@ -47,8 +73,9 @@ def rescore_submission(submission_id: str, background_tasks: BackgroundTasks) ->
         row["team_id"],
         row.get("text_answer") or "",
         row.get("photo_url"),
+        bool(payload.force),
     )
-    return {"status": "queued", "submission_id": submission_id}
+    return {"status": "queued", "submission_id": submission_id, "force": bool(payload.force)}
 
 
 class CriteriaIn(BaseModel):

--- a/backend/routes/organizer.py
+++ b/backend/routes/organizer.py
@@ -59,7 +59,7 @@ def rescore_submission(
         supabase.table("review_queue").insert(
             {
                 "submission_id": row["id"],
-                "suggested_score": int(row.get("score") or 0),
+                "claude_score": int(row.get("score") or 0),
                 "claude_rationale": (row.get("rationale") or "Rescore requested").strip() or "Rescore requested",
             }
         ).execute()

--- a/backend/routes/submissions.py
+++ b/backend/routes/submissions.py
@@ -1,9 +1,11 @@
 import uuid
 
 import anyio
-from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile
+from pydantic import BaseModel
 from typing import Any, Dict, Optional
 
+from auth.organizer import require_organizer
 from services import get_supabase
 from services.scoring import score_submission
 from services.storage import storage_bucket
@@ -168,6 +170,61 @@ async def create_submission(
     }
     supabase.table("submissions").insert(submission).execute()
     
-    background_tasks.add_task(score_submission, submission_id, task_id, team_id, normalized_text_answer, photo_path)
+    background_tasks.add_task(score_submission, submission_id, task_id, team_id, normalized_text_answer, photo_path, False)
     
     return {"submission_id": submission_id, "status": "pending"}
+
+
+class RescoreIn(BaseModel):
+    force: bool = False
+
+
+@router.post("/{id}/rescore", dependencies=[Depends(require_organizer)])
+def rescore_submission(
+    id: str,
+    payload: RescoreIn,
+    background_tasks: BackgroundTasks,
+) -> Dict[str, Any]:
+    supabase = get_supabase()
+
+    row = (
+        supabase.table("submissions")
+        .select("id,task_id,team_id,text_answer,photo_url,status,score,rationale,ai_result")
+        .eq("id", id)
+        .maybe_single()
+        .execute()
+        .data
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    terminal_statuses = {"auto_approved", "reviewed"}
+    if (row.get("status") in terminal_statuses) and (not payload.force):
+        raise HTTPException(
+            status_code=400,
+            detail="Submission is already in a terminal state; set force=true to override.",
+        )
+
+    # Audit trail: `review_queue` requires NOT NULL suggested_score and claude_rationale.
+    try:
+        supabase.table("review_queue").insert(
+            {
+                "submission_id": row["id"],
+                "suggested_score": int(row.get("score") or 0),
+                "claude_rationale": (row.get("rationale") or "Rescore requested").strip() or "Rescore requested",
+            }
+        ).execute()
+    except Exception:
+        # Avoid blocking rescore if audit logging fails (e.g., table missing in dev).
+        pass
+
+    background_tasks.add_task(
+        score_submission,
+        row["id"],
+        row["task_id"],
+        row["team_id"],
+        row.get("text_answer") or "",
+        row.get("photo_url"),
+        bool(payload.force),
+    )
+    return {"status": "queued", "submission_id": row["id"], "force": bool(payload.force)}

--- a/backend/routes/submissions.py
+++ b/backend/routes/submissions.py
@@ -210,7 +210,7 @@ def rescore_submission(
         supabase.table("review_queue").insert(
             {
                 "submission_id": row["id"],
-                "suggested_score": int(row.get("score") or 0),
+                "claude_score": int(row.get("score") or 0),
                 "claude_rationale": (row.get("rationale") or "Rescore requested").strip() or "Rescore requested",
             }
         ).execute()

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -103,8 +103,14 @@ def _mark_submission_error(
     ai_result: Optional[Dict[str, Any]] = None,
 ):
     payload: Dict[str, Any] = {"status": "error", "rationale": message}
-    if ai_result is not None:
-        payload["ai_result"] = ai_result
+    normalized_ai_result: Dict[str, Any] = {}
+    if isinstance(ai_result, dict):
+        normalized_ai_result.update(ai_result)
+    if "error" not in normalized_ai_result or not str(normalized_ai_result.get("error") or "").strip():
+        normalized_ai_result["error"] = message
+    if "mode" not in normalized_ai_result:
+        normalized_ai_result["mode"] = "error"
+    payload["ai_result"] = normalized_ai_result
     supabase.table("submissions").update(payload).eq("id", submission_id).execute()
 
 
@@ -121,11 +127,12 @@ async def score_submission(
     team_id: str,
     text_answer: Optional[str],
     photo_path: Optional[str],
+    force: bool = False,
 ):
     try:
         supabase = get_supabase()
 
-        # Idempotency: if already finalized, don't rescore (prevents double-counting team totals).
+        # Idempotency: if already terminal, don't rescore unless forced.
         existing = (
             supabase.table("submissions")
             .select("status")
@@ -134,7 +141,8 @@ async def score_submission(
             .execute()
             .data
         )
-        if existing and existing.get("status") in {"approved", "flagged", "rejected"}:
+        terminal_statuses = {"auto_approved", "reviewed"}
+        if (not force) and existing and existing.get("status") in terminal_statuses:
             return
 
         openai_client = _get_openai_client()
@@ -378,7 +386,12 @@ Score this submission. Return JSON only:
     except Exception as e:
         try:
             supabase = get_supabase()
-            _mark_submission_error(supabase, submission_id, f"Scoring exception: {e}")
+            _mark_submission_error(
+                supabase,
+                submission_id,
+                f"Scoring exception: {e}",
+                ai_result={"mode": "exception", "error": str(e)},
+            )
         except Exception:
             pass
         print(f"Scoring error: {e}")
@@ -394,6 +407,21 @@ def _finalize_score(
     status: str,
     ai_result: Optional[Dict[str, Any]] = None,
 ):
+    previous_score: Optional[int] = None
+    try:
+        existing = (
+            supabase.table("submissions")
+            .select("score")
+            .eq("id", submission_id)
+            .single()
+            .execute()
+            .data
+        )
+        if existing and existing.get("score") is not None:
+            previous_score = int(existing["score"])
+    except Exception:
+        previous_score = None
+
     supabase.table("submissions").update(
         {
             "status": status,
@@ -403,11 +431,12 @@ def _finalize_score(
             "ai_result": ai_result,
         }
     ).eq("id", submission_id).execute()
-    
-    # Update team total score
+
+    # Update team total score by delta to avoid double-counting on rescore.
     try:
         team = supabase.table("teams").select("total_score").eq("id", team_id).single().execute().data
-        new_total = (team["total_score"] or 0) + score
-        supabase.table("teams").update({"total_score": new_total}).eq("id", team_id).execute()
+        current_total = int(team.get("total_score") or 0)
+        delta = int(score) - int(previous_score or 0)
+        supabase.table("teams").update({"total_score": current_total + delta}).eq("id", team_id).execute()
     except Exception:
         pass

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -141,7 +141,7 @@ async def score_submission(
             .execute()
             .data
         )
-        terminal_statuses = {"auto_approved", "reviewed"}
+        terminal_statuses = {"approved", "flagged", "error", "auto_approved", "reviewed"}
         if (not force) and existing and existing.get("status") in terminal_statuses:
             return
 

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -111,7 +111,7 @@ class _FakeSupabase:
 @pytest.mark.asyncio
 async def test_score_submission_idempotent(monkeypatch):
     # If a submission is already in a terminal state, score_submission should no-op early (unless forced).
-    fake = _FakeSupabase(status="reviewed")
+    fake = _FakeSupabase(status="approved")
     monkeypatch.setattr(scoring, "get_supabase", lambda: fake)
 
     # If it doesn't early return, it will try to build clients and/or query tasks and the fake will explode.

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -110,8 +110,8 @@ class _FakeSupabase:
 
 @pytest.mark.asyncio
 async def test_score_submission_idempotent(monkeypatch):
-    # If a submission is already approved/flagged/rejected, score_submission should no-op early.
-    fake = _FakeSupabase(status="approved")
+    # If a submission is already in a terminal state, score_submission should no-op early (unless forced).
+    fake = _FakeSupabase(status="reviewed")
     monkeypatch.setattr(scoring, "get_supabase", lambda: fake)
 
     # If it doesn't early return, it will try to build clients and/or query tasks and the fake will explode.

--- a/backend/tests/test_submissions_rescore.py
+++ b/backend/tests/test_submissions_rescore.py
@@ -1,0 +1,160 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+try:
+    import python_multipart as _pm  # noqa: F401
+
+    _HAVE_MULTIPART = True
+except Exception:
+    try:
+        import multipart as _mp  # type: ignore  # noqa: F401
+
+        _HAVE_MULTIPART = True
+    except Exception:
+        _HAVE_MULTIPART = False
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Query:
+    def __init__(self, db, name):
+        self._db = db
+        self._name = name
+        self._filters = {}
+        self._single = False
+        self._insert_payloads = []
+
+    def select(self, _cols="*"):
+        return self
+
+    def eq(self, k, v):
+        self._filters[k] = v
+        return self
+
+    def maybe_single(self):
+        self._single = True
+        return self
+
+    def single(self):
+        self._single = True
+        return self
+
+    def insert(self, payload):
+        self._insert_payloads.append(payload)
+        if isinstance(payload, dict):
+            self._db.setdefault(self._name, []).append(payload)
+        elif isinstance(payload, list):
+            self._db.setdefault(self._name, []).extend(payload)
+        return self
+
+    def execute(self):
+        rows = list(self._db.get(self._name, []))
+        for k, v in self._filters.items():
+            rows = [r for r in rows if r.get(k) == v]
+        if self._single:
+            return _Resp(rows[0] if rows else None)
+        return _Resp(rows)
+
+
+class _FakeSupabase:
+    def __init__(self, submission_row):
+        self.db = {"submissions": [submission_row], "review_queue": []}
+
+    def table(self, name):
+        return _Query(self.db, name)
+
+
+@pytest.fixture()
+def app_client(monkeypatch):
+    if not _HAVE_MULTIPART:
+        pytest.skip('FastAPI Form/File routes require "python-multipart"')
+
+    from routes import submissions as submissions_routes
+
+    called = {"calls": [], "review_queue_rows": None}
+
+    def _fake_score_submission(*args, **kwargs):
+        called["calls"].append((args, kwargs))
+
+    submission = {
+        "id": "sub1",
+        "task_id": "task1",
+        "team_id": "team1",
+        "text_answer": "hi",
+        "photo_url": None,
+        "status": "pending",
+        "score": 3,
+        "rationale": "ok",
+        "ai_result": None,
+    }
+    fake = _FakeSupabase(submission)
+
+    monkeypatch.setattr(submissions_routes, "get_supabase", lambda: fake)
+    monkeypatch.setattr(submissions_routes, "score_submission", _fake_score_submission)
+
+    app = FastAPI()
+    app.include_router(submissions_routes.router, prefix="/submissions")
+
+    return TestClient(app), fake, called
+
+
+def test_rescore_requires_organizer_header(monkeypatch, app_client):
+    client, _fake, _called = app_client
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    resp = client.post("/submissions/sub1/rescore", json={"force": False})
+    assert resp.status_code == 401
+    assert "X-Organizer-Code" in resp.json()["detail"]
+
+
+def test_rescore_non_terminal_queues_and_logs(monkeypatch, app_client):
+    client, fake, called = app_client
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    resp = client.post("/submissions/sub1/rescore", headers={"X-Organizer-Code": "secret"}, json={"force": False})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert body["submission_id"] == "sub1"
+    assert body["force"] is False
+
+    assert fake.db["review_queue"], "expected audit row inserted into review_queue"
+    audit = fake.db["review_queue"][0]
+    assert audit["submission_id"] == "sub1"
+    assert audit["suggested_score"] == 3
+    assert audit["claude_rationale"] == "ok"
+
+    assert called["calls"], "expected score_submission to be queued via BackgroundTasks"
+    args, _kwargs = called["calls"][0]
+    assert args[-1] is False  # force
+
+
+def test_rescore_terminal_without_force_returns_400(monkeypatch, app_client):
+    client, fake, called = app_client
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    fake.db["submissions"][0]["status"] = "reviewed"
+
+    resp = client.post("/submissions/sub1/rescore", headers={"X-Organizer-Code": "secret"}, json={"force": False})
+    assert resp.status_code == 400
+    assert called["calls"] == []
+
+
+def test_rescore_terminal_with_force_queues(monkeypatch, app_client):
+    client, fake, called = app_client
+    monkeypatch.setenv("ORGANIZER_DEMO_CODE", "secret")
+
+    fake.db["submissions"][0]["status"] = "reviewed"
+
+    resp = client.post("/submissions/sub1/rescore", headers={"X-Organizer-Code": "secret"}, json={"force": True})
+    assert resp.status_code == 200
+    assert resp.json()["force"] is True
+
+    assert called["calls"], "expected score_submission to be queued"
+    args, _kwargs = called["calls"][0]
+    assert args[-1] is True  # force
+

--- a/backend/tests/test_submissions_rescore.py
+++ b/backend/tests/test_submissions_rescore.py
@@ -125,7 +125,7 @@ def test_rescore_non_terminal_queues_and_logs(monkeypatch, app_client):
     assert fake.db["review_queue"], "expected audit row inserted into review_queue"
     audit = fake.db["review_queue"][0]
     assert audit["submission_id"] == "sub1"
-    assert audit["suggested_score"] == 3
+    assert audit["claude_score"] == 3
     assert audit["claude_rationale"] == "ok"
 
     assert called["calls"], "expected score_submission to be queued via BackgroundTasks"


### PR DESCRIPTION
# What
Organizers can rescore any submission, with a force flag to override terminal states. Team totals update by delta so rescoring doesn't corrupt the leaderboard. Every attempt is logged to review_queue for auditability, and error paths now always surface a reason in ai_result.

# Why
Organizers need a way to correct bad AI scores without corrupting team totals or losing the audit trail