### PR TITLE
Add shared loading + error UI to distinguish network vs server failur…

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -4,6 +4,7 @@ import { Platform, StyleSheet } from 'react-native';
 import { Collapsible } from '@/components/ui/collapsible';
 import { ExternalLink } from '@/components/external-link';
 import ParallaxScrollView from '@/components/parallax-scroll-view';
+import { ScreenState } from '@/components/screen-state';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { IconSymbol } from '@/components/ui/icon-symbol';
@@ -11,104 +12,114 @@ import { Fonts } from '@/constants/theme';
 
 export default function TabTwoScreen() {
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
-      headerImage={
-        <IconSymbol
-          size={310}
-          color="#808080"
-          name="chevron.left.forwardslash.chevron.right"
-          style={styles.headerImage}
-        />
-      }
-    >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText
-          type="title"
-          style={{
-            fontFamily: Fonts.rounded,
-          }}
-        >
-          Explore
-        </ThemedText>
-      </ThemedView>
-      <ThemedText>
-        This app includes example code to help you get started.
-      </ThemedText>
-      <Collapsible title="File-based routing">
+    <ScreenState isLoading={false}>
+      <ParallaxScrollView
+        headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+        headerImage={
+          <IconSymbol
+            size={310}
+            color="#808080"
+            name="chevron.left.forwardslash.chevron.right"
+            style={styles.headerImage}
+          />
+        }
+      >
+        <ThemedView style={styles.titleContainer}>
+          <ThemedText
+            type="title"
+            style={{
+              fontFamily: Fonts.rounded,
+            }}
+          >
+            Explore
+          </ThemedText>
+        </ThemedView>
         <ThemedText>
-          This app has two screens:{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>{' '}
-          and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
+          This app includes example code to help you get started.
         </ThemedText>
-        <ThemedText>
-          The layout file in{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}
-          sets up the tab navigator.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/router/introduction">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Android, iOS, and web support">
-        <ThemedText>
-          You can open this project on Android, iOS, and the web. To open the
-          web version, press <ThemedText type="defaultSemiBold">w</ThemedText>{' '}
-          in the terminal running this project.
-        </ThemedText>
-      </Collapsible>
-      <Collapsible title="Images">
-        <ThemedText>
-          For static images, you can use the{' '}
-          <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to
-          provide files for different screen densities
-        </ThemedText>
-        <Image
-          source={require('@/assets/images/react-logo.png')}
-          style={{ width: 100, height: 100, alignSelf: 'center' }}
-        />
-        <ExternalLink href="https://reactnative.dev/docs/images">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Light and dark mode components">
-        <ThemedText>
-          This template has light and dark mode support. The{' '}
-          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook
-          lets you inspect what the user&apos;s current color scheme is, and so
-          you can adjust UI colors accordingly.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Animations">
-        <ThemedText>
-          This template includes an example of an animated component. The{' '}
-          <ThemedText type="defaultSemiBold">
-            components/HelloWave.tsx
-          </ThemedText>{' '}
-          component uses the powerful{' '}
-          <ThemedText type="defaultSemiBold" style={{ fontFamily: Fonts.mono }}>
-            react-native-reanimated
-          </ThemedText>{' '}
-          library to create a waving hand animation.
-        </ThemedText>
-        {Platform.select({
-          ios: (
-            <ThemedText>
-              The{' '}
-              <ThemedText type="defaultSemiBold">
-                components/ParallaxScrollView.tsx
-              </ThemedText>{' '}
-              component provides a parallax effect for the header image.
+        <Collapsible title="File-based routing">
+          <ThemedText>
+            This app has two screens:{' '}
+            <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>{' '}
+            and{' '}
+            <ThemedText type="defaultSemiBold">
+              app/(tabs)/explore.tsx
             </ThemedText>
-          ),
-        })}
-      </Collapsible>
-    </ParallaxScrollView>
+          </ThemedText>
+          <ThemedText>
+            The layout file in{' '}
+            <ThemedText type="defaultSemiBold">
+              app/(tabs)/_layout.tsx
+            </ThemedText>{' '}
+            sets up the tab navigator.
+          </ThemedText>
+          <ExternalLink href="https://docs.expo.dev/router/introduction">
+            <ThemedText type="link">Learn more</ThemedText>
+          </ExternalLink>
+        </Collapsible>
+        <Collapsible title="Android, iOS, and web support">
+          <ThemedText>
+            You can open this project on Android, iOS, and the web. To open the
+            web version, press{' '}
+            <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal
+            running this project.
+          </ThemedText>
+        </Collapsible>
+        <Collapsible title="Images">
+          <ThemedText>
+            For static images, you can use the{' '}
+            <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
+            <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to
+            provide files for different screen densities
+          </ThemedText>
+          <Image
+            source={require('@/assets/images/react-logo.png')}
+            style={{ width: 100, height: 100, alignSelf: 'center' }}
+          />
+          <ExternalLink href="https://reactnative.dev/docs/images">
+            <ThemedText type="link">Learn more</ThemedText>
+          </ExternalLink>
+        </Collapsible>
+        <Collapsible title="Light and dark mode components">
+          <ThemedText>
+            This template has light and dark mode support. The{' '}
+            <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText>{' '}
+            hook lets you inspect what the user&apos;s current color scheme is,
+            and so you can adjust UI colors accordingly.
+          </ThemedText>
+          <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
+            <ThemedText type="link">Learn more</ThemedText>
+          </ExternalLink>
+        </Collapsible>
+        <Collapsible title="Animations">
+          <ThemedText>
+            This template includes an example of an animated component. The{' '}
+            <ThemedText type="defaultSemiBold">
+              components/HelloWave.tsx
+            </ThemedText>{' '}
+            component uses the powerful{' '}
+            <ThemedText
+              type="defaultSemiBold"
+              style={{ fontFamily: Fonts.mono }}
+            >
+              react-native-reanimated
+            </ThemedText>{' '}
+            library to create a waving hand animation.
+          </ThemedText>
+          {Platform.select({
+            ios: (
+              <ThemedText>
+                The{' '}
+                <ThemedText type="defaultSemiBold">
+                  components/ParallaxScrollView.tsx
+                </ThemedText>{' '}
+                component provides a parallax effect for the header image.
+              </ThemedText>
+            ),
+          })}
+        </Collapsible>
+      </ParallaxScrollView>
+    </ScreenState>
   );
 }
 

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -60,9 +60,8 @@ export default function TabTwoScreen() {
         <Collapsible title="Android, iOS, and web support">
           <ThemedText>
             You can open this project on Android, iOS, and the web. To open the
-            web version, press{' '}
-            <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal
-            running this project.
+            web version, press <ThemedText type="defaultSemiBold">w</ThemedText>{' '}
+            in the terminal running this project.
           </ThemedText>
         </Collapsible>
         <Collapsible title="Images">

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,87 +3,90 @@ import { Platform, StyleSheet } from 'react-native';
 
 import { HelloWave } from '@/components/hello-wave';
 import ParallaxScrollView from '@/components/parallax-scroll-view';
+import { ScreenState } from '@/components/screen-state';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { Link } from 'expo-router';
 
 export default function HomeScreen() {
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }
-    >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>{' '}
-          to see changes. Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <Link href="/modal">
-          <Link.Trigger>
-            <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-          </Link.Trigger>
-          <Link.Preview />
-          <Link.Menu>
-            <Link.MenuAction
-              title="Action"
-              icon="cube"
-              onPress={() => alert('Action pressed')}
-            />
-            <Link.MenuAction
-              title="Share"
-              icon="square.and.arrow.up"
-              onPress={() => alert('Share pressed')}
-            />
-            <Link.Menu title="More" icon="ellipsis">
+    <ScreenState isLoading={false}>
+      <ParallaxScrollView
+        headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+        headerImage={
+          <Image
+            source={require('@/assets/images/partial-react-logo.png')}
+            style={styles.reactLogo}
+          />
+        }
+      >
+        <ThemedView style={styles.titleContainer}>
+          <ThemedText type="title">Welcome!</ThemedText>
+          <HelloWave />
+        </ThemedView>
+        <ThemedView style={styles.stepContainer}>
+          <ThemedText type="subtitle">Step 1: Try it</ThemedText>
+          <ThemedText>
+            Edit{' '}
+            <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>{' '}
+            to see changes. Press{' '}
+            <ThemedText type="defaultSemiBold">
+              {Platform.select({
+                ios: 'cmd + d',
+                android: 'cmd + m',
+                web: 'F12',
+              })}
+            </ThemedText>{' '}
+            to open developer tools.
+          </ThemedText>
+        </ThemedView>
+        <ThemedView style={styles.stepContainer}>
+          <Link href="/modal">
+            <Link.Trigger>
+              <ThemedText type="subtitle">Step 2: Explore</ThemedText>
+            </Link.Trigger>
+            <Link.Preview />
+            <Link.Menu>
               <Link.MenuAction
-                title="Delete"
-                icon="trash"
-                destructive
-                onPress={() => alert('Delete pressed')}
+                title="Action"
+                icon="cube"
+                onPress={() => alert('Action pressed')}
               />
+              <Link.MenuAction
+                title="Share"
+                icon="square.and.arrow.up"
+                onPress={() => alert('Share pressed')}
+              />
+              <Link.Menu title="More" icon="ellipsis">
+                <Link.MenuAction
+                  title="Delete"
+                  icon="trash"
+                  destructive
+                  onPress={() => alert('Delete pressed')}
+                />
+              </Link.Menu>
             </Link.Menu>
-          </Link.Menu>
-        </Link>
+          </Link>
 
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">
-            npm run reset-project
-          </ThemedText>{' '}
-          to get a fresh <ThemedText type="defaultSemiBold">app</ThemedText>{' '}
-          directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+          <ThemedText>
+            {`Tap the Explore tab to learn more about what's included in this starter app.`}
+          </ThemedText>
+        </ThemedView>
+        <ThemedView style={styles.stepContainer}>
+          <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
+          <ThemedText>
+            {`When you're ready, run `}
+            <ThemedText type="defaultSemiBold">
+              npm run reset-project
+            </ThemedText>{' '}
+            to get a fresh <ThemedText type="defaultSemiBold">app</ThemedText>{' '}
+            directory. This will move the current{' '}
+            <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
+            <ThemedText type="defaultSemiBold">app-example</ThemedText>.
+          </ThemedText>
+        </ThemedView>
+      </ParallaxScrollView>
+    </ScreenState>
   );
 }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,9 +15,10 @@ import {
   JosefinSlab_400Regular,
   JosefinSlab_600SemiBold,
 } from '@expo-google-fonts/josefin-slab';
+import { View } from 'react-native';
 
 import { AppErrorBoundary } from '@/components/app-error-boundary';
-import { AppLoading } from '@/components/app-loading';
+import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export const unstable_settings = {
@@ -34,7 +35,15 @@ export default function RootLayout() {
   });
 
   if (!fontsLoaded) {
-    return <AppLoading label="Getting things ready…" />;
+    // Avoid ThemedText / custom fonts before they're loaded.
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: Colors.light.background,
+        }}
+      />
+    );
   }
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,7 +6,18 @@ import {
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import { useFonts } from 'expo-font';
+import {
+  JosefinSans_400Regular,
+  JosefinSans_600SemiBold,
+} from '@expo-google-fonts/josefin-sans';
+import {
+  JosefinSlab_400Regular,
+  JosefinSlab_600SemiBold,
+} from '@expo-google-fonts/josefin-slab';
 
+import { AppErrorBoundary } from '@/components/app-error-boundary';
+import { AppLoading } from '@/components/app-loading';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export const unstable_settings = {
@@ -15,17 +26,29 @@ export const unstable_settings = {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const [fontsLoaded] = useFonts({
+    JosefinSans_400Regular,
+    JosefinSans_600SemiBold,
+    JosefinSlab_400Regular,
+    JosefinSlab_600SemiBold,
+  });
+
+  if (!fontsLoaded) {
+    return <AppLoading label="Getting things ready…" />;
+  }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="modal"
-          options={{ presentation: 'modal', title: 'Modal' }}
-        />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <AppErrorBoundary>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="modal"
+            options={{ presentation: 'modal', title: 'Modal' }}
+          />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </AppErrorBoundary>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,15 @@
+import { Text, View } from 'react-native';
+
+export default function Index() {
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Text>Edit app/index.tsx to edit this screen.</Text>
+    </View>
+  );
+}

--- a/components/app-error-boundary.tsx
+++ b/components/app-error-boundary.tsx
@@ -30,4 +30,3 @@ export function AppErrorBoundary({
     </ErrorBoundary>
   );
 }
-

--- a/components/app-error-boundary.tsx
+++ b/components/app-error-boundary.tsx
@@ -1,0 +1,33 @@
+import type { PropsWithChildren } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { AppErrorState } from '@/components/app-error-state';
+import { toAppError } from '@/lib/app-error';
+
+export type AppErrorBoundaryProps = PropsWithChildren<{
+  onResetToSafeRoute?: () => void;
+}>;
+
+export function AppErrorBoundary({
+  children,
+  onResetToSafeRoute,
+}: AppErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      onReset={onResetToSafeRoute}
+      fallbackRender={({ error, resetErrorBoundary }) => (
+        <AppErrorState
+          error={toAppError(error)}
+          onRetry={() => {
+            resetErrorBoundary();
+            onResetToSafeRoute?.();
+          }}
+          titleOverride="App error"
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+

--- a/components/app-error-state.tsx
+++ b/components/app-error-state.tsx
@@ -19,7 +19,8 @@ function getDefaultCopy(error: AppError): { title: string; message: string } {
     case 'network':
       return {
         title: 'No connection',
-        message: 'Looks like you’re offline. Check your connection and try again.',
+        message:
+          'Looks like you’re offline. Check your connection and try again.',
       };
     case 'server':
       return {
@@ -48,7 +49,8 @@ export function AppErrorState({
   const message = error.message?.trim() ? error.message : copy.message;
 
   const canGoBack = router.canGoBack();
-  const handleGoBack = onGoBack ?? (canGoBack ? () => router.back() : undefined);
+  const handleGoBack =
+    onGoBack ?? (canGoBack ? () => router.back() : undefined);
   const primaryAction =
     onRetry ?? handleGoBack ?? (() => router.replace('/(tabs)'));
 
@@ -135,4 +137,3 @@ const styles = StyleSheet.create({
     opacity: 0.85,
   },
 });
-

--- a/components/app-error-state.tsx
+++ b/components/app-error-state.tsx
@@ -1,0 +1,138 @@
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { router } from 'expo-router';
+
+import type { AppError } from '@/lib/app-error';
+import { Colors } from '@/constants/theme';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type AppErrorStateProps = {
+  error: AppError;
+  onRetry?: () => void;
+  onGoBack?: () => void;
+  titleOverride?: string;
+};
+
+function getDefaultCopy(error: AppError): { title: string; message: string } {
+  switch (error.kind) {
+    case 'network':
+      return {
+        title: 'No connection',
+        message: 'Looks like you’re offline. Check your connection and try again.',
+      };
+    case 'server':
+      return {
+        title: 'Server error',
+        message: 'Our servers are having a moment. Please try again.',
+      };
+    default:
+      return {
+        title: 'Something went wrong',
+        message: 'Try again, or head back and try a different path.',
+      };
+  }
+}
+
+export function AppErrorState({
+  error,
+  onRetry,
+  onGoBack,
+  titleOverride,
+}: AppErrorStateProps) {
+  const theme = useColorScheme() ?? 'light';
+  const tint = Colors[theme].tint;
+
+  const copy = getDefaultCopy(error);
+  const title = titleOverride ?? copy.title;
+  const message = error.message?.trim() ? error.message : copy.message;
+
+  const canGoBack = router.canGoBack();
+  const handleGoBack = onGoBack ?? (canGoBack ? () => router.back() : undefined);
+  const primaryAction =
+    onRetry ?? handleGoBack ?? (() => router.replace('/(tabs)'));
+
+  const primaryLabel = onRetry ? 'Retry' : handleGoBack ? 'Go back' : 'Go home';
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.content}>
+        <ThemedText type="title" style={styles.title}>
+          {title}
+        </ThemedText>
+        <ThemedText style={styles.message}>{message}</ThemedText>
+
+        <View style={styles.actions}>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            onPress={primaryAction}
+            style={[styles.primaryButton, { borderColor: tint }]}
+          >
+            <ThemedText
+              type="defaultSemiBold"
+              style={[styles.primaryText, { color: tint }]}
+            >
+              {primaryLabel}
+            </ThemedText>
+          </TouchableOpacity>
+
+          {onRetry && handleGoBack ? (
+            <TouchableOpacity
+              activeOpacity={0.85}
+              onPress={handleGoBack}
+              style={styles.secondaryButton}
+            >
+              <ThemedText style={styles.secondaryText}>Go back</ThemedText>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  content: {
+    width: '100%',
+    maxWidth: 520,
+    gap: 12,
+    alignItems: 'center',
+  },
+  title: {
+    textAlign: 'center',
+  },
+  message: {
+    textAlign: 'center',
+    opacity: 0.9,
+  },
+  actions: {
+    marginTop: 8,
+    gap: 10,
+    width: '100%',
+  },
+  primaryButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  primaryText: {
+    fontSize: 16,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+  },
+  secondaryText: {
+    opacity: 0.85,
+  },
+});
+

--- a/components/app-loading.tsx
+++ b/components/app-loading.tsx
@@ -10,7 +10,10 @@ export type AppLoadingProps = {
   fullScreen?: boolean;
 };
 
-export function AppLoading({ label = 'Loading…', fullScreen = true }: AppLoadingProps) {
+export function AppLoading({
+  label = 'Loading…',
+  fullScreen = true,
+}: AppLoadingProps) {
   const colorScheme = useColorScheme();
   const spinnerColor = Colors[colorScheme ?? 'light'].tint;
 
@@ -42,4 +45,3 @@ const styles = StyleSheet.create({
     opacity: 0.9,
   },
 });
-

--- a/components/app-loading.tsx
+++ b/components/app-loading.tsx
@@ -1,0 +1,45 @@
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+import { Colors } from '@/constants/theme';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export type AppLoadingProps = {
+  label?: string;
+  fullScreen?: boolean;
+};
+
+export function AppLoading({ label = 'Loading…', fullScreen = true }: AppLoadingProps) {
+  const colorScheme = useColorScheme();
+  const spinnerColor = Colors[colorScheme ?? 'light'].tint;
+
+  const content = (
+    <View style={styles.content}>
+      <ActivityIndicator size="large" color={spinnerColor} />
+      {label ? <ThemedText style={styles.label}>{label}</ThemedText> : null}
+    </View>
+  );
+
+  if (!fullScreen) return content;
+
+  return <ThemedView style={styles.fullScreen}>{content}</ThemedView>;
+}
+
+const styles = StyleSheet.create({
+  fullScreen: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  content: {
+    alignItems: 'center',
+    gap: 12,
+  },
+  label: {
+    textAlign: 'center',
+    opacity: 0.9,
+  },
+});
+

--- a/components/screen-state.tsx
+++ b/components/screen-state.tsx
@@ -19,7 +19,7 @@ export function ScreenState({
   children,
 }: ScreenStateProps) {
   if (isLoading) return <AppLoading label={loadingLabel} />;
-  if (error) return <AppErrorState error={toAppError(error)} onRetry={onRetry} />;
+  if (error)
+    return <AppErrorState error={toAppError(error)} onRetry={onRetry} />;
   return children;
 }
-

--- a/components/screen-state.tsx
+++ b/components/screen-state.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react';
+
+import { AppErrorState } from '@/components/app-error-state';
+import { AppLoading } from '@/components/app-loading';
+import { toAppError } from '@/lib/app-error';
+
+export type ScreenStateProps = PropsWithChildren<{
+  isLoading: boolean;
+  error?: unknown;
+  onRetry?: () => void;
+  loadingLabel?: string;
+}>;
+
+export function ScreenState({
+  isLoading,
+  error,
+  onRetry,
+  loadingLabel,
+  children,
+}: ScreenStateProps) {
+  if (isLoading) return <AppLoading label={loadingLabel} />;
+  if (error) return <AppErrorState error={toAppError(error)} onRetry={onRetry} />;
+  return children;
+}
+

--- a/components/themed-text.tsx
+++ b/components/themed-text.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, type TextProps } from 'react-native';
 
+import { Fonts } from '@/constants/theme';
 import { useThemeColor } from '@/hooks/use-theme-color';
 
 export type ThemedTextProps = TextProps & {
@@ -37,24 +38,29 @@ const styles = StyleSheet.create({
   default: {
     fontSize: 16,
     lineHeight: 24,
+    fontFamily: Fonts?.sans,
   },
   defaultSemiBold: {
     fontSize: 16,
     lineHeight: 24,
+    fontFamily: Fonts?.sans,
     fontWeight: '600',
   },
   title: {
     fontSize: 32,
-    fontWeight: 'bold',
+    fontFamily: Fonts?.serif,
+    fontWeight: '600',
     lineHeight: 32,
   },
   subtitle: {
     fontSize: 20,
-    fontWeight: 'bold',
+    fontFamily: Fonts?.serif,
+    fontWeight: '600',
   },
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
+    fontFamily: Fonts?.sans,
+    color: '#E8821A',
   },
 });

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -5,16 +5,22 @@
 
 import { Platform } from 'react-native';
 
-const tintColorLight = '#0a7ea4';
+// Brand tokens (light)
+const brandBackgroundLight = '#FEF3E2';
+const brandAccentOrange = '#E8821A';
+const brandBrown = '#3D2B1A';
+const brandBrick = '#B84C2B';
+
+const tintColorLight = brandAccentOrange;
 const tintColorDark = '#fff';
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
+    text: brandBrown,
+    background: brandBackgroundLight,
     tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
+    icon: brandBrick,
+    tabIconDefault: brandBrick,
     tabIconSelected: tintColorLight,
   },
   dark: {
@@ -29,22 +35,22 @@ export const Colors = {
 
 export const Fonts = Platform.select({
   ios: {
-    /** iOS `UIFontDescriptorSystemDesignDefault` */
-    sans: 'system-ui',
-    /** iOS `UIFontDescriptorSystemDesignSerif` */
-    serif: 'ui-serif',
+    // Loaded via expo-font in `app/_layout.tsx`
+    sans: 'JosefinSans_400Regular',
+    serif: 'JosefinSlab_400Regular',
     /** iOS `UIFontDescriptorSystemDesignRounded` */
     rounded: 'ui-rounded',
     /** iOS `UIFontDescriptorSystemDesignMonospaced` */
     mono: 'ui-monospace',
   },
   default: {
-    sans: 'normal',
-    serif: 'serif',
+    sans: 'JosefinSans_400Regular',
+    serif: 'JosefinSlab_400Regular',
     rounded: 'normal',
     mono: 'monospace',
   },
   web: {
+    // Keep web on system fonts unless you add CSS font loading.
     sans: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
     serif: "Georgia, 'Times New Roman', serif",
     rounded:

--- a/lib/app-error.ts
+++ b/lib/app-error.ts
@@ -32,7 +32,8 @@ function getHttpStatus(err: unknown): number | undefined {
   if (typeof status === 'number' && Number.isFinite(status)) return status;
 
   const response = err.response;
-  if (isRecord(response) && typeof response.status === 'number') return response.status;
+  if (isRecord(response) && typeof response.status === 'number')
+    return response.status;
 
   return undefined;
 }
@@ -51,4 +52,3 @@ export function toAppError(err: unknown): AppError {
 
   return { kind: 'unknown', status, message, cause: err };
 }
-

--- a/lib/app-error.ts
+++ b/lib/app-error.ts
@@ -1,0 +1,54 @@
+export type AppErrorKind = 'network' | 'server' | 'unknown';
+
+export type AppError = {
+  kind: AppErrorKind;
+  message?: string;
+  status?: number;
+  cause?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getErrorMessage(err: unknown): string | undefined {
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) return err.message;
+  if (isRecord(err) && typeof err.message === 'string') return err.message;
+  return undefined;
+}
+
+function isLikelyNetworkError(err: unknown): boolean {
+  const message = getErrorMessage(err);
+  if (!message) return false;
+  return /network request failed|failed to fetch|load failed|internet connection appears to be offline/i.test(
+    message,
+  );
+}
+
+function getHttpStatus(err: unknown): number | undefined {
+  if (!isRecord(err)) return undefined;
+  const status = err.status;
+  if (typeof status === 'number' && Number.isFinite(status)) return status;
+
+  const response = err.response;
+  if (isRecord(response) && typeof response.status === 'number') return response.status;
+
+  return undefined;
+}
+
+export function toAppError(err: unknown): AppError {
+  const status = getHttpStatus(err);
+  const message = getErrorMessage(err);
+
+  if (isLikelyNetworkError(err)) {
+    return { kind: 'network', message, cause: err };
+  }
+
+  if (typeof status === 'number' && status >= 500) {
+    return { kind: 'server', status, message, cause: err };
+  }
+
+  return { kind: 'unknown', status, message, cause: err };
+}
+

--- a/lib/app-error.ts
+++ b/lib/app-error.ts
@@ -7,6 +7,15 @@ export type AppError = {
   cause?: unknown;
 };
 
+export function isAppError(err: unknown): err is AppError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'kind' in err &&
+    typeof (err as { kind?: unknown }).kind === 'string'
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -39,6 +48,8 @@ function getHttpStatus(err: unknown): number | undefined {
 }
 
 export function toAppError(err: unknown): AppError {
+  if (isAppError(err)) return err;
+
   const status = getHttpStatus(err);
   const message = getErrorMessage(err);
 

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,59 @@
+import type { AppError } from '@/lib/app-error';
+import { toAppError } from '@/lib/app-error';
+
+export type HttpJsonInit = RequestInit & {
+  headers?: Record<string, string>;
+};
+
+export async function httpJson<T>(
+  url: string,
+  init: HttpJsonInit = {},
+): Promise<T> {
+  try {
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        accept: 'application/json',
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!res.ok) {
+      const status = res.status;
+      let message: string | undefined;
+      try {
+        const contentType = res.headers.get('content-type') ?? '';
+        if (contentType.includes('application/json')) {
+          const body = (await res.json()) as unknown;
+          if (typeof body === 'string') message = body;
+          else if (
+            typeof body === 'object' &&
+            body !== null &&
+            'message' in body &&
+            typeof (body as { message?: unknown }).message === 'string'
+          ) {
+            message = (body as { message: string }).message;
+          }
+        } else {
+          const text = await res.text();
+          if (text.trim()) message = text;
+        }
+      } catch {
+        // ignore body parse errors
+      }
+
+      const err: AppError = {
+        kind: status >= 500 ? 'server' : 'unknown',
+        status,
+        message,
+        cause: { url },
+      };
+      throw err;
+    }
+
+    return (await res.json()) as T;
+  } catch (err) {
+    throw toAppError(err);
+  }
+}
+

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -56,4 +56,3 @@ export async function httpJson<T>(
     throw toAppError(err);
   }
 }
-

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,5 +1,5 @@
 import type { AppError } from '@/lib/app-error';
-import { toAppError } from '@/lib/app-error';
+import { isAppError, toAppError } from '@/lib/app-error';
 
 export type HttpJsonInit = RequestInit & {
   headers?: Record<string, string>;
@@ -53,6 +53,7 @@ export async function httpJson<T>(
 
     return (await res.json()) as T;
   } catch (err) {
+    if (isAppError(err)) throw err;
     throw toAppError(err);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "sapsut",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/josefin-sans": "^0.4.2",
+        "@expo-google-fonts/josefin-slab": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
@@ -26,6 +28,7 @@
         "expo-web-browser": "~15.0.10",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-error-boundary": "^6.1.1",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
@@ -1743,6 +1746,18 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/josefin-sans": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/josefin-sans/-/josefin-sans-0.4.2.tgz",
+      "integrity": "sha512-aVxfoUme2j7eQlPQzfXLPhqn3rimsMPH7QcsBhSP2PqXAkAgcbBhmYd2X1XIrxvXTQBAIHVWE8AgmoVIcnrYmw==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/josefin-slab": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/josefin-slab/-/josefin-slab-0.4.1.tgz",
+      "integrity": "sha512-si72R2W3np+fMWELgd1BfikFlK/ozefuSzP14XCXqWRKnnB7b/VvMy96HesZ8tP5ZouNdQ7iCipUuPowFFG9SQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
@@ -10221,6 +10236,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
+      "integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@expo-google-fonts/josefin-sans": "^0.4.2",
+    "@expo-google-fonts/josefin-slab": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
@@ -31,20 +33,21 @@
     "expo-web-browser": "~15.0.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-error-boundary": "^6.1.1",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "typescript": "~5.9.2",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
-    "prettier": "^3.8.3"
+    "prettier": "^3.8.3",
+    "typescript": "~5.9.2"
   },
   "private": true
 }


### PR DESCRIPTION
# What

Screens now handle loading and error states consistently through a ScreenState wrapper. A typed httpJson helper and toAppError utility normalize all fetch errors into a consistent shape before they reach the UI. Brand colors (warm orange, brown, brick) and Josefin Sans/Slab fonts replace the Expo defaults app-wide.

# Why
Centralizing error handling means submission flow and organizer dashboard screens get consistent error UX.