### PR TITLE
Build submission form with photo selection and conditional inputs

### DIFF
--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -34,9 +34,8 @@ export default function TaskSubmitScreen() {
 
   const [teamId, setTeamId] = useState('');
   const [textAnswer, setTextAnswer] = useState('');
-  const [photoAsset, setPhotoAsset] = useState<ImagePicker.ImagePickerAsset | null>(
-    null,
-  );
+  const [photoAsset, setPhotoAsset] =
+    useState<ImagePicker.ImagePickerAsset | null>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -53,7 +52,7 @@ export default function TaskSubmitScreen() {
         const tasks = await httpJson<Task[]>(apiUrl('/tasks/'));
         const found =
           Array.isArray(tasks) && taskId
-            ? tasks.find((t) => String(t.id) === taskId) ?? null
+            ? (tasks.find((t) => String(t.id) === taskId) ?? null)
             : null;
         if (mounted) setTask(found);
       } catch (e) {
@@ -270,10 +269,7 @@ export default function TaskSubmitScreen() {
                     pressed ? styles.buttonPressed : null,
                   ]}
                 >
-                  <ThemedText
-                    type="defaultSemiBold"
-                    style={{ color: tint }}
-                  >
+                  <ThemedText type="defaultSemiBold" style={{ color: tint }}>
                     {photoAsset ? 'Replace photo' : 'Pick a photo'}
                   </ThemedText>
                 </Pressable>
@@ -309,7 +305,8 @@ export default function TaskSubmitScreen() {
 
           {submitSuccessId ? (
             <ThemedText style={styles.successText}>
-              Submitted. ID: <ThemedText type="defaultSemiBold">{submitSuccessId}</ThemedText>
+              Submitted. ID:{' '}
+              <ThemedText type="defaultSemiBold">{submitSuccessId}</ThemedText>
             </ThemedText>
           ) : null}
 

--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -178,10 +178,14 @@ export default function TaskSubmitScreen() {
       }
 
       const ok = body as CreateSubmissionOk | null;
-      if (ok?.submission_id) {
+      if (ok?.submission_id && ok?.status !== 'error') {
         setSubmitSuccessId(ok.submission_id);
       } else {
-        setSubmitError('Submission failed. Please try again.');
+        setSubmitError(
+          ok?.status === 'error'
+            ? 'Photo upload failed. Please try again.'
+            : 'Submission failed. Please try again.',
+        );
       }
     } catch (e) {
       setSubmitError(

--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -1,11 +1,197 @@
-import { StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { apiUrl } from '@/lib/api';
+import { httpJson } from '@/lib/http';
+
+type Task = {
+  id: string | number;
+  title: string;
+  description: string | null;
+  type: 'text' | 'photo' | 'combo';
+  max_points: number;
+};
+
+type CreateSubmissionOk = { submission_id: string; status: string };
+type CreateSubmissionError = { error: string; existing_submission_id?: string };
+type CreateSubmissionResponse = CreateSubmissionOk | CreateSubmissionError;
 
 export default function TaskSubmitScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const theme = useColorScheme() ?? 'light';
+  const border = Colors[theme].icon;
+  const tint = Colors[theme].tint;
+
+  const [task, setTask] = useState<Task | null>(null);
+  const [isLoadingTask, setIsLoadingTask] = useState(true);
+  const [taskError, setTaskError] = useState<unknown>(undefined);
+
+  const [teamId, setTeamId] = useState('');
+  const [textAnswer, setTextAnswer] = useState('');
+  const [photoAsset, setPhotoAsset] = useState<ImagePicker.ImagePickerAsset | null>(
+    null,
+  );
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccessId, setSubmitSuccessId] = useState<string | null>(null);
+
+  const taskId = String(id ?? '');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setIsLoadingTask(true);
+      setTaskError(undefined);
+      try {
+        const tasks = await httpJson<Task[]>(apiUrl('/tasks/'));
+        const found =
+          Array.isArray(tasks) && taskId
+            ? tasks.find((t) => String(t.id) === taskId) ?? null
+            : null;
+        if (mounted) setTask(found);
+      } catch (e) {
+        if (mounted) setTaskError(e);
+      } finally {
+        if (mounted) setIsLoadingTask(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [taskId]);
+
+  const submissionType = task?.type;
+  const wantsText = submissionType === 'text' || submissionType === 'combo';
+  const wantsPhoto = submissionType === 'photo' || submissionType === 'combo';
+
+  const canSubmit = useMemo(() => {
+    if (!taskId.trim()) return false;
+    if (!teamId.trim()) return false;
+    if (!submissionType) return false;
+    if (isSubmitting) return false;
+    if (wantsText && wantsPhoto) {
+      return Boolean(textAnswer.trim() || photoAsset);
+    }
+    if (wantsText) return Boolean(textAnswer.trim());
+    if (wantsPhoto) return Boolean(photoAsset);
+    return false;
+  }, [
+    isSubmitting,
+    photoAsset,
+    submissionType,
+    taskId,
+    teamId,
+    textAnswer,
+    wantsPhoto,
+    wantsText,
+  ]);
+
+  const onPickPhoto = useCallback(async () => {
+    setSubmitError(null);
+    setSubmitSuccessId(null);
+
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) {
+      setSubmitError('Photo permission is required to pick an image.');
+      return;
+    }
+
+    const res = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      quality: 0.9,
+    });
+    if (res.canceled) return;
+    const asset = res.assets?.[0] ?? null;
+    setPhotoAsset(asset);
+  }, []);
+
+  const onRemovePhoto = useCallback(() => {
+    setPhotoAsset(null);
+  }, []);
+
+  const onSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitSuccessId(null);
+
+    try {
+      const fd = new FormData();
+      fd.append('task_id', taskId);
+      fd.append('team_id', teamId.trim());
+
+      if (textAnswer.trim()) {
+        fd.append('text_answer', textAnswer);
+      }
+
+      if (photoAsset?.uri) {
+        const uri = photoAsset.uri;
+        const name = uri.split('/').pop() || 'photo.jpg';
+        const ext = name.split('.').pop()?.toLowerCase();
+        const type =
+          ext === 'png'
+            ? 'image/png'
+            : ext === 'webp'
+              ? 'image/webp'
+              : 'image/jpeg';
+
+        fd.append('photo', {
+          uri,
+          name,
+          type,
+        } as unknown as Blob);
+      }
+
+      const res = await fetch(apiUrl('/submissions/'), {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          // NOTE: Do not set Content-Type for FormData in React Native.
+        },
+        body: fd,
+      });
+
+      let body: CreateSubmissionResponse | null = null;
+      try {
+        body = (await res.json()) as CreateSubmissionResponse;
+      } catch {
+        body = null;
+      }
+
+      if (!res.ok) {
+        setSubmitError('Submission failed. Please try again.');
+        return;
+      }
+
+      if (body && typeof body === 'object' && 'error' in body) {
+        setSubmitError(
+          body.error || 'Duplicate submission blocked for this task.',
+        );
+        return;
+      }
+
+      const ok = body as CreateSubmissionOk | null;
+      if (ok?.submission_id) {
+        setSubmitSuccessId(ok.submission_id);
+      } else {
+        setSubmitError('Submission failed. Please try again.');
+      }
+    } catch (e) {
+      setSubmitError(
+        e instanceof Error ? e.message : 'Submission failed. Please try again.',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [canSubmit, photoAsset, taskId, teamId, textAnswer]);
 
   return (
     <>
@@ -13,10 +199,133 @@ export default function TaskSubmitScreen() {
       <ThemedView style={styles.container}>
         <View style={styles.content}>
           <ThemedText type="title">Submission</ThemedText>
-          <ThemedText style={styles.hint}>
-            Submission form coming next. Task id:
-          </ThemedText>
-          <ThemedText type="defaultSemiBold">{String(id ?? '')}</ThemedText>
+
+          {isLoadingTask ? (
+            <ThemedText style={styles.hint}>Loading task…</ThemedText>
+          ) : task ? (
+            <View style={styles.taskHeader}>
+              <ThemedText type="subtitle">{task.title}</ThemedText>
+              <ThemedText style={styles.hint}>
+                Submission type:{' '}
+                <ThemedText type="defaultSemiBold">{task.type}</ThemedText>
+              </ThemedText>
+            </View>
+          ) : (
+            <ThemedText style={styles.hint}>
+              Couldn’t load task. (id: {taskId})
+            </ThemedText>
+          )}
+
+          {taskError ? (
+            <ThemedText style={[styles.hint, { color: tint }]}>
+              Failed to load task list.
+            </ThemedText>
+          ) : null}
+
+          <View style={styles.field}>
+            <ThemedText type="defaultSemiBold">Team ID</ThemedText>
+            <TextInput
+              value={teamId}
+              onChangeText={setTeamId}
+              placeholder="UUID of your team"
+              placeholderTextColor={border}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!isSubmitting}
+              style={[
+                styles.input,
+                { borderColor: border, color: Colors[theme].text },
+              ]}
+            />
+          </View>
+
+          {wantsText ? (
+            <View style={styles.field}>
+              <ThemedText type="defaultSemiBold">Text answer</ThemedText>
+              <TextInput
+                value={textAnswer}
+                onChangeText={setTextAnswer}
+                placeholder="Type your answer…"
+                placeholderTextColor={border}
+                editable={!isSubmitting}
+                multiline
+                style={[
+                  styles.textarea,
+                  { borderColor: border, color: Colors[theme].text },
+                ]}
+              />
+            </View>
+          ) : null}
+
+          {wantsPhoto ? (
+            <View style={styles.field}>
+              <ThemedText type="defaultSemiBold">Photo</ThemedText>
+              <View style={styles.photoRow}>
+                <Pressable
+                  onPress={onPickPhoto}
+                  disabled={isSubmitting}
+                  style={({ pressed }) => [
+                    styles.button,
+                    { borderColor: tint },
+                    pressed ? styles.buttonPressed : null,
+                  ]}
+                >
+                  <ThemedText
+                    type="defaultSemiBold"
+                    style={{ color: tint }}
+                  >
+                    {photoAsset ? 'Replace photo' : 'Pick a photo'}
+                  </ThemedText>
+                </Pressable>
+                {photoAsset ? (
+                  <Pressable
+                    onPress={onRemovePhoto}
+                    disabled={isSubmitting}
+                    style={({ pressed }) => [
+                      styles.button,
+                      { borderColor: border },
+                      pressed ? styles.buttonPressed : null,
+                    ]}
+                  >
+                    <ThemedText type="defaultSemiBold">Remove</ThemedText>
+                  </Pressable>
+                ) : null}
+              </View>
+              {photoAsset ? (
+                <ThemedText style={styles.hint}>
+                  Selected: {photoAsset.fileName ?? photoAsset.uri}
+                </ThemedText>
+              ) : (
+                <ThemedText style={styles.hint}>No photo selected.</ThemedText>
+              )}
+            </View>
+          ) : null}
+
+          {submitError ? (
+            <ThemedText style={[styles.errorText, { color: tint }]}>
+              {submitError}
+            </ThemedText>
+          ) : null}
+
+          {submitSuccessId ? (
+            <ThemedText style={styles.successText}>
+              Submitted. ID: <ThemedText type="defaultSemiBold">{submitSuccessId}</ThemedText>
+            </ThemedText>
+          ) : null}
+
+          <Pressable
+            onPress={onSubmit}
+            disabled={!canSubmit}
+            style={({ pressed }) => [
+              styles.submitButton,
+              { backgroundColor: canSubmit ? tint : border },
+              pressed && canSubmit ? styles.submitPressed : null,
+            ]}
+          >
+            <ThemedText type="defaultSemiBold" style={styles.submitText}>
+              {isSubmitting ? 'Submitting…' : 'Submit'}
+            </ThemedText>
+          </Pressable>
         </View>
       </ThemedView>
     </>
@@ -31,7 +340,64 @@ const styles = StyleSheet.create({
   content: {
     gap: 10,
   },
+  taskHeader: {
+    gap: 4,
+  },
   hint: {
     opacity: 0.85,
+  },
+  field: {
+    gap: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  textarea: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    minHeight: 110,
+    textAlignVertical: 'top',
+  },
+  photoRow: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  button: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  buttonPressed: {
+    opacity: 0.85,
+    transform: [{ scale: 0.99 }],
+  },
+  errorText: {
+    opacity: 0.95,
+  },
+  successText: {
+    opacity: 0.95,
+  },
+  submitButton: {
+    borderRadius: 14,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 6,
+  },
+  submitPressed: {
+    opacity: 0.9,
+    transform: [{ scale: 0.995 }],
+  },
+  submitText: {
+    color: 'white',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
-        "expo-image-picker": "^55.0.19",
+        "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
@@ -7094,21 +7094,21 @@
       }
     },
     "node_modules/expo-image-loader": {
-      "version": "55.0.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
-      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "55.0.19",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.19.tgz",
-      "integrity": "sha512-PqOOfRz7+hbB9IFN0LfNxpJJwuPlUG0Abr0qM3Wc61OJ7FFyuKJ50QJ/fFItzSuoXifET1YIFBiXx5nA8Gkinw==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
+      "integrity": "sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==",
       "license": "MIT",
       "dependencies": {
-        "expo-image-loader": "~55.0.0"
+        "expo-image-loader": "~6.0.0"
       },
       "peerDependencies": {
         "expo": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-picker": "^55.0.19",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
@@ -7090,6 +7091,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.19.tgz",
+      "integrity": "sha512-PqOOfRz7+hbB9IFN0LfNxpJJwuPlUG0Abr0qM3Wc61OJ7FFyuKJ50QJ/fFItzSuoXifET1YIFBiXx5nA8Gkinw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-picker": "^55.0.19",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
-    "expo-image-picker": "^55.0.19",
+    "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",


### PR DESCRIPTION
# What
The submission screen fetches the task on load and renders inputs conditionally based on submission type — text only, photo only, or both. Photo selection uses expo-image-picker with permission handling. Duplicate submission errors and success confirmation are surfaced inline.

# Why
Inputs render conditionally based on task type so the form never asks for more than the task requires. Duplicate submission errors are caught at the response layer rather than disabled at the UI layer so teams get an explicit message.