### PR TITLE
Add camera capture and user photo upload to supabase

### DIFF
--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -377,11 +377,15 @@ export default function TaskSubmitScreen() {
                   {photoPath ? (
                     <ThemedText style={styles.hint}>
                       Uploaded path:{' '}
-                      <ThemedText type="defaultSemiBold">{photoPath}</ThemedText>
+                      <ThemedText type="defaultSemiBold">
+                        {photoPath}
+                      </ThemedText>
                     </ThemedText>
                   ) : null}
                   {isUploadingPhoto ? (
-                    <ThemedText style={styles.hint}>Uploading photo…</ThemedText>
+                    <ThemedText style={styles.hint}>
+                      Uploading photo…
+                    </ThemedText>
                   ) : null}
                 </>
               ) : (

--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Pressable, StyleSheet, TextInput, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
+import { Image } from 'expo-image';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
@@ -9,6 +10,7 @@ import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { apiUrl } from '@/lib/api';
 import { httpJson } from '@/lib/http';
+import { uploadSubmissionPhoto } from '@/lib/storage';
 
 type Task = {
   id: string | number;
@@ -36,12 +38,21 @@ export default function TaskSubmitScreen() {
   const [textAnswer, setTextAnswer] = useState('');
   const [photoAsset, setPhotoAsset] =
     useState<ImagePicker.ImagePickerAsset | null>(null);
+  const [photoPath, setPhotoPath] = useState<string | null>(null);
+  const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
+  const [cameraAvailable, setCameraAvailable] = useState<boolean | null>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccessId, setSubmitSuccessId] = useState<string | null>(null);
 
   const taskId = String(id ?? '');
+
+  useEffect(() => {
+    // `expo-image-picker` does not reliably expose a camera-availability API across SDKs.
+    // Treat native platforms as "camera capable" and fallback at runtime if launching fails.
+    setCameraAvailable(Platform.OS === 'ios' || Platform.OS === 'android');
+  }, []);
 
   useEffect(() => {
     let mounted = true;
@@ -95,6 +106,7 @@ export default function TaskSubmitScreen() {
   const onPickPhoto = useCallback(async () => {
     setSubmitError(null);
     setSubmitSuccessId(null);
+    setPhotoPath(null);
 
     const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!perm.granted) {
@@ -112,8 +124,38 @@ export default function TaskSubmitScreen() {
     setPhotoAsset(asset);
   }, []);
 
+  const onTakePhoto = useCallback(async () => {
+    setSubmitError(null);
+    setSubmitSuccessId(null);
+    setPhotoPath(null);
+
+    const perm = await ImagePicker.requestCameraPermissionsAsync();
+    if (!perm.granted) {
+      setSubmitError('Camera permission is required to take a photo.');
+      return;
+    }
+
+    let res: ImagePicker.ImagePickerResult;
+    try {
+      res = await ImagePicker.launchCameraAsync({
+        mediaTypes: ['images'],
+        allowsEditing: true,
+        quality: 0.9,
+      });
+    } catch {
+      // Fallback to library if camera isn't available (e.g., simulator) or fails to launch.
+      setCameraAvailable(false);
+      await onPickPhoto();
+      return;
+    }
+    if (res.canceled) return;
+    const asset = res.assets?.[0] ?? null;
+    setPhotoAsset(asset);
+  }, [onPickPhoto]);
+
   const onRemovePhoto = useCallback(() => {
     setPhotoAsset(null);
+    setPhotoPath(null);
   }, []);
 
   const onSubmit = useCallback(async () => {
@@ -123,6 +165,30 @@ export default function TaskSubmitScreen() {
     setSubmitSuccessId(null);
 
     try {
+      let uploadedPath: string | null = photoPath;
+
+      if (photoAsset && !uploadedPath) {
+        setIsUploadingPhoto(true);
+        try {
+          const { path } = await uploadSubmissionPhoto({
+            asset: photoAsset,
+            teamId,
+            taskId,
+          });
+          uploadedPath = path;
+          setPhotoPath(path);
+        } catch (e) {
+          setSubmitError(
+            e instanceof Error
+              ? e.message
+              : 'Photo upload failed. Please try again.',
+          );
+          return;
+        } finally {
+          setIsUploadingPhoto(false);
+        }
+      }
+
       const fd = new FormData();
       fd.append('task_id', taskId);
       fd.append('team_id', teamId.trim());
@@ -131,22 +197,8 @@ export default function TaskSubmitScreen() {
         fd.append('text_answer', textAnswer);
       }
 
-      if (photoAsset?.uri) {
-        const uri = photoAsset.uri;
-        const name = uri.split('/').pop() || 'photo.jpg';
-        const ext = name.split('.').pop()?.toLowerCase();
-        const type =
-          ext === 'png'
-            ? 'image/png'
-            : ext === 'webp'
-              ? 'image/webp'
-              : 'image/jpeg';
-
-        fd.append('photo', {
-          uri,
-          name,
-          type,
-        } as unknown as Blob);
+      if (uploadedPath) {
+        fd.append('photo_path', uploadedPath);
       }
 
       const res = await fetch(apiUrl('/submissions/'), {
@@ -192,9 +244,10 @@ export default function TaskSubmitScreen() {
         e instanceof Error ? e.message : 'Submission failed. Please try again.',
       );
     } finally {
+      setIsUploadingPhoto(false);
       setIsSubmitting(false);
     }
-  }, [canSubmit, photoAsset, taskId, teamId, textAnswer]);
+  }, [canSubmit, photoAsset, photoPath, taskId, teamId, textAnswer]);
 
   return (
     <>
@@ -265,6 +318,23 @@ export default function TaskSubmitScreen() {
               <ThemedText type="defaultSemiBold">Photo</ThemedText>
               <View style={styles.photoRow}>
                 <Pressable
+                  onPress={onTakePhoto}
+                  disabled={isSubmitting}
+                  style={({ pressed }) => [
+                    styles.button,
+                    { borderColor: tint },
+                    pressed ? styles.buttonPressed : null,
+                  ]}
+                >
+                  <ThemedText type="defaultSemiBold" style={{ color: tint }}>
+                    {cameraAvailable === false
+                      ? 'Camera unavailable'
+                      : photoAsset
+                        ? 'Retake photo'
+                        : 'Take photo'}
+                  </ThemedText>
+                </Pressable>
+                <Pressable
                   onPress={onPickPhoto}
                   disabled={isSubmitting}
                   style={({ pressed }) => [
@@ -274,7 +344,7 @@ export default function TaskSubmitScreen() {
                   ]}
                 >
                   <ThemedText type="defaultSemiBold" style={{ color: tint }}>
-                    {photoAsset ? 'Replace photo' : 'Pick a photo'}
+                    {photoAsset ? 'Pick different' : 'Pick from library'}
                   </ThemedText>
                 </Pressable>
                 {photoAsset ? (
@@ -292,9 +362,28 @@ export default function TaskSubmitScreen() {
                 ) : null}
               </View>
               {photoAsset ? (
-                <ThemedText style={styles.hint}>
-                  Selected: {photoAsset.fileName ?? photoAsset.uri}
-                </ThemedText>
+                <>
+                  <ThemedText style={styles.hint}>
+                    Selected: {photoAsset.fileName ?? photoAsset.uri}
+                  </ThemedText>
+                  <View style={styles.previewFrame}>
+                    <Image
+                      source={{ uri: photoAsset.uri }}
+                      style={styles.previewImage}
+                      contentFit="cover"
+                      accessibilityLabel="Selected photo preview"
+                    />
+                  </View>
+                  {photoPath ? (
+                    <ThemedText style={styles.hint}>
+                      Uploaded path:{' '}
+                      <ThemedText type="defaultSemiBold">{photoPath}</ThemedText>
+                    </ThemedText>
+                  ) : null}
+                  {isUploadingPhoto ? (
+                    <ThemedText style={styles.hint}>Uploading photo…</ThemedText>
+                  ) : null}
+                </>
               ) : (
                 <ThemedText style={styles.hint}>No photo selected.</ThemedText>
               )}
@@ -381,6 +470,17 @@ const styles = StyleSheet.create({
   buttonPressed: {
     opacity: 0.85,
     transform: [{ scale: 0.99 }],
+  },
+  previewFrame: {
+    marginTop: 10,
+    borderRadius: 16,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.08)',
+  },
+  previewImage: {
+    width: '100%',
+    height: 220,
   },
   errorText: {
     opacity: 0.95,

--- a/backend/routes/submissions.py
+++ b/backend/routes/submissions.py
@@ -128,7 +128,7 @@ async def create_submission(
     normalized_text_answer = text_answer or ""
     normalized_photo_path = (photo_path or "").strip() or None
     if not normalized_text_answer.strip() and (photo is None) and (normalized_photo_path is None):
-        return {"error": "Submission must include text_answer or photo."}
+        return {"error": "Submission must include text_answer, photo, or photo_path."}
 
     stored_photo_path = normalized_photo_path
     if (stored_photo_path is None) and (photo is not None):

--- a/backend/routes/submissions.py
+++ b/backend/routes/submissions.py
@@ -89,7 +89,8 @@ async def create_submission(
     task_id: str = Form(...),
     team_id: str = Form(...),
     text_answer: str = Form(None),
-    photo: UploadFile = File(None)
+    photo_path: str = Form(None),
+    photo: UploadFile = File(None),
 ):
     submission_id = str(uuid.uuid4())
     supabase = get_supabase()
@@ -125,21 +126,22 @@ async def create_submission(
             }
 
     normalized_text_answer = text_answer or ""
-    if not normalized_text_answer.strip() and photo is None:
+    normalized_photo_path = (photo_path or "").strip() or None
+    if not normalized_text_answer.strip() and (photo is None) and (normalized_photo_path is None):
         return {"error": "Submission must include text_answer or photo."}
 
-    photo_path = None
-    if photo is not None:
+    stored_photo_path = normalized_photo_path
+    if (stored_photo_path is None) and (photo is not None):
         # Important: read and upload during the request lifecycle.
         photo_bytes = await photo.read()
         content_type = (photo.content_type or "application/octet-stream").strip()
         ext = (content_type.split("/")[-1] if "/" in content_type else "bin") or "bin"
-        photo_path = f"{team_id}/{task_id}/{submission_id}.{ext}"
+        stored_photo_path = f"{team_id}/{task_id}/{submission_id}.{ext}"
         try:
             # Supabase Storage upload is synchronous; offload to worker thread.
             await anyio.to_thread.run_sync(
                 lambda: supabase.storage.from_(storage_bucket()).upload(
-                    photo_path,
+                    stored_photo_path,
                     photo_bytes,
                     file_options={"content-type": content_type, "upsert": True},
                 )
@@ -165,12 +167,12 @@ async def create_submission(
         "team_id": team_id,
         "text_answer": normalized_text_answer,
         # Persist object path in existing schema column name.
-        "photo_url": photo_path,
+        "photo_url": stored_photo_path,
         "status": "pending"
     }
     supabase.table("submissions").insert(submission).execute()
     
-    background_tasks.add_task(score_submission, submission_id, task_id, team_id, normalized_text_answer, photo_path, False)
+    background_tasks.add_task(score_submission, submission_id, task_id, team_id, normalized_text_answer, stored_photo_path, False)
     
     return {"submission_id": submission_id, "status": "pending"}
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -8,7 +8,12 @@ function guessImageExt(asset: ImagePicker.ImagePickerAsset): string {
   if (fromName && /^[a-z0-9]{1,6}$/.test(fromName)) return fromName;
 
   const uri = asset.uri ?? '';
-  const fromUri = uri.split('?')[0]?.split('#')[0]?.split('.').pop()?.toLowerCase();
+  const fromUri = uri
+    .split('?')[0]
+    ?.split('#')[0]
+    ?.split('.')
+    .pop()
+    ?.toLowerCase();
   if (fromUri && /^[a-z0-9]{1,6}$/.test(fromUri)) return fromUri;
 
   return 'jpg';
@@ -40,9 +45,10 @@ export async function uploadSubmissionPhoto(params: {
   bucket?: string;
 }): Promise<{ path: string }> {
   const { asset, teamId, taskId } = params;
-  const bucket = (params.bucket ?? process.env.EXPO_PUBLIC_SUPABASE_STORAGE_BUCKET)
-    ?.trim()
-    .slice(0, 200) || 'submission-photos';
+  const bucket =
+    (params.bucket ?? process.env.EXPO_PUBLIC_SUPABASE_STORAGE_BUCKET)
+      ?.trim()
+      .slice(0, 200) || 'submission-photos';
 
   if (!asset?.uri) throw new Error('Missing photo URI.');
   if (!teamId.trim()) throw new Error('Missing team id.');
@@ -64,4 +70,3 @@ export async function uploadSubmissionPhoto(params: {
 
   return { path };
 }
-

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -64,7 +64,7 @@ export async function uploadSubmissionPhoto(params: {
   const supabase = getSupabaseClient();
   const { error } = await supabase.storage.from(bucket).upload(path, blob, {
     contentType,
-    upsert: true,
+    upsert: false,
   });
   if (error) throw new Error(error.message || 'Upload failed.');
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,67 @@
+import type * as ImagePicker from 'expo-image-picker';
+
+import { getSupabaseClient } from '@/lib/supabase';
+
+function guessImageExt(asset: ImagePicker.ImagePickerAsset): string {
+  const name = asset.fileName ?? '';
+  const fromName = name.split('.').pop()?.toLowerCase();
+  if (fromName && /^[a-z0-9]{1,6}$/.test(fromName)) return fromName;
+
+  const uri = asset.uri ?? '';
+  const fromUri = uri.split('?')[0]?.split('#')[0]?.split('.').pop()?.toLowerCase();
+  if (fromUri && /^[a-z0-9]{1,6}$/.test(fromUri)) return fromUri;
+
+  return 'jpg';
+}
+
+function guessContentType(ext: string): string {
+  switch (ext) {
+    case 'png':
+      return 'image/png';
+    case 'webp':
+      return 'image/webp';
+    case 'heic':
+      return 'image/heic';
+    case 'heif':
+      return 'image/heif';
+    default:
+      return 'image/jpeg';
+  }
+}
+
+function makeId(): string {
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export async function uploadSubmissionPhoto(params: {
+  asset: ImagePicker.ImagePickerAsset;
+  teamId: string;
+  taskId: string;
+  bucket?: string;
+}): Promise<{ path: string }> {
+  const { asset, teamId, taskId } = params;
+  const bucket = (params.bucket ?? process.env.EXPO_PUBLIC_SUPABASE_STORAGE_BUCKET)
+    ?.trim()
+    .slice(0, 200) || 'submission-photos';
+
+  if (!asset?.uri) throw new Error('Missing photo URI.');
+  if (!teamId.trim()) throw new Error('Missing team id.');
+  if (!taskId.trim()) throw new Error('Missing task id.');
+
+  const ext = guessImageExt(asset);
+  const contentType = guessContentType(ext);
+  const path = `${teamId.trim()}/${taskId.trim()}/${makeId()}.${ext}`;
+
+  // In Expo/RN, local file URIs can be fetched and converted to a Blob.
+  const blob = await (await fetch(asset.uri)).blob();
+
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.storage.from(bucket).upload(path, blob, {
+    contentType,
+    upsert: true,
+  });
+  if (error) throw new Error(error.message || 'Upload failed.');
+
+  return { path };
+}
+

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -23,4 +23,3 @@ export function getSupabaseClient(): SupabaseClient {
   });
   return _client;
 }
-

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,26 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let _client: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (_client) return _client;
+
+  const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error(
+      'Missing Supabase env vars. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY.',
+    );
+  }
+
+  _client = createClient(url, anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+  return _client;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "@supabase/supabase-js": "^2.104.1",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -3672,6 +3673,113 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.1.tgz",
+      "integrity": "sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.1.tgz",
+      "integrity": "sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.1.tgz",
+      "integrity": "sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.1.tgz",
+      "integrity": "sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.1.tgz",
+      "integrity": "sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.1.tgz",
+      "integrity": "sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.104.1",
+        "@supabase/functions-js": "2.104.1",
+        "@supabase/postgrest-js": "2.104.1",
+        "@supabase/realtime-js": "2.104.1",
+        "@supabase/storage-js": "2.104.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -4042,6 +4150,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -8391,6 +8508,15 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@supabase/supabase-js": "^2.104.1",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",


### PR DESCRIPTION
# What
Photos are now uploaded directly from the frontend to Supabase Storage before the submission is posted and the backend receives a storage path instead of raw bytes. Camera capture is added alongside library picker, with a runtime fallback to the library if the camera fails or isn't available. A photo preview renders inline after selection. 

# Why
Sending raw image bytes through the backend on every submission adds unnecessary latency and load on the API process. Uploading directly from the client and passing the path keeps the submission request light and mirrors how the scoring pipeline already expects to consume photos- by path from storage.