### PR TITLE
Add organizer reveiw queue UI

### DIFF
--- a/app/organizer/review.tsx
+++ b/app/organizer/review.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import { Stack } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { organizerJson } from '@/lib/organizer-api';
+
+type Submission = {
+  id: string;
+  task_id: string;
+  team_id: string;
+  text_answer: string | null;
+  photo_url: string | null;
+  status: string | null;
+  score: number | null;
+  confidence: number | null;
+  rationale: string | null;
+  gpt4o_description: string | null;
+  created_at: string | null;
+};
+
+type ReviewQueueRow = {
+  id: string;
+  submission_id: string;
+  claude_score: number | null;
+  confidence: number | null;
+  claude_rationale: string | null;
+  created_at: string | null;
+  submission?: Submission | null;
+};
+
+export default function OrganizerReviewDashboard() {
+  const theme = useColorScheme() ?? 'light';
+  const tint = Colors[theme].tint;
+  const border = Colors[theme].icon;
+
+  const [organizerCode, setOrganizerCode] = useState('');
+  const [rows, setRows] = useState<ReviewQueueRow[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [overrideScores, setOverrideScores] = useState<Record<string, string>>(
+    {},
+  );
+  const [busyById, setBusyById] = useState<Record<string, boolean>>({});
+
+  const canLoad = useMemo(() => Boolean(organizerCode.trim()), [organizerCode]);
+
+  const loadQueue = useCallback(async () => {
+    if (!organizerCode.trim()) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await organizerJson<ReviewQueueRow[]>(
+        '/organizer/review-queue',
+        organizerCode,
+      );
+      setRows(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load review queue.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [organizerCode]);
+
+  useEffect(() => {
+    // Don’t auto-fire without the code; wait for user input.
+    setRows([]);
+    setError(null);
+  }, [organizerCode]);
+
+  const setBusy = useCallback((id: string, v: boolean) => {
+    setBusyById((prev) => ({ ...prev, [id]: v }));
+  }, []);
+
+  const onApprove = useCallback(
+    async (row: ReviewQueueRow) => {
+      if (!organizerCode.trim()) return;
+      setBusy(row.id, true);
+      setError(null);
+      try {
+        await organizerJson(
+          `/organizer/review-queue/${row.id}/approve`,
+          organizerCode,
+          { method: 'POST' },
+        );
+        setRows((prev) => prev.filter((r) => r.id !== row.id));
+      } catch (e) {
+        setError(
+          e instanceof Error ? e.message : 'Approve failed. Please try again.',
+        );
+      } finally {
+        setBusy(row.id, false);
+      }
+    },
+    [organizerCode, setBusy],
+  );
+
+  const onOverride = useCallback(
+    async (row: ReviewQueueRow) => {
+      if (!organizerCode.trim()) return;
+      const raw = (overrideScores[row.id] ?? '').trim();
+      const score = Number(raw);
+      if (!Number.isFinite(score) || score < 0) {
+        setError('Enter a valid non-negative score to override.');
+        return;
+      }
+
+      setBusy(row.id, true);
+      setError(null);
+      try {
+        await organizerJson(
+          `/organizer/review-queue/${row.id}/override`,
+          organizerCode,
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ score }),
+          },
+        );
+        setRows((prev) => prev.filter((r) => r.id !== row.id));
+      } catch (e) {
+        setError(
+          e instanceof Error ? e.message : 'Override failed. Please try again.',
+        );
+      } finally {
+        setBusy(row.id, false);
+      }
+    },
+    [organizerCode, overrideScores, setBusy],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ReviewQueueRow }) => {
+      const s = item.submission ?? null;
+      const content =
+        (s?.gpt4o_description ?? '').trim() ||
+        (s?.text_answer ?? '').trim() ||
+        '(No submission content)';
+
+      const busy = Boolean(busyById[item.id]);
+      const suggested = item.claude_score;
+
+      return (
+        <View style={[styles.card, { borderColor: border }]}>
+          <View style={styles.cardHeader}>
+            <ThemedText type="defaultSemiBold">Submission</ThemedText>
+            <ThemedText style={styles.meta}>
+              Queue ID:{' '}
+              <ThemedText type="defaultSemiBold">{item.id}</ThemedText>
+            </ThemedText>
+          </View>
+
+          <ThemedText style={styles.body}>{content}</ThemedText>
+
+          <View style={styles.row}>
+            <ThemedText type="defaultSemiBold">Suggested score:</ThemedText>
+            <ThemedText>{suggested ?? '—'}</ThemedText>
+          </View>
+          <View style={styles.row}>
+            <ThemedText type="defaultSemiBold">Claude rationale:</ThemedText>
+          </View>
+          <ThemedText style={styles.body}>
+            {(item.claude_rationale ?? '').trim() || '—'}
+          </ThemedText>
+
+          <View style={styles.actions}>
+            <Pressable
+              onPress={() => onApprove(item)}
+              disabled={busy || suggested === null || suggested === undefined}
+              style={({ pressed }) => [
+                styles.button,
+                { borderColor: tint },
+                pressed ? styles.buttonPressed : null,
+              ]}
+            >
+              <ThemedText type="defaultSemiBold" style={{ color: tint }}>
+                Approve
+              </ThemedText>
+            </Pressable>
+
+            <View style={styles.overrideBox}>
+              <TextInput
+                value={overrideScores[item.id] ?? ''}
+                onChangeText={(t) =>
+                  setOverrideScores((prev) => ({ ...prev, [item.id]: t }))
+                }
+                placeholder="Custom score"
+                placeholderTextColor={border}
+                keyboardType="number-pad"
+                editable={!busy}
+                style={[
+                  styles.input,
+                  { borderColor: border, color: Colors[theme].text },
+                ]}
+              />
+              <Pressable
+                onPress={() => onOverride(item)}
+                disabled={busy}
+                style={({ pressed }) => [
+                  styles.button,
+                  { borderColor: border },
+                  pressed ? styles.buttonPressed : null,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold">Override</ThemedText>
+              </Pressable>
+            </View>
+
+            {busy ? <ActivityIndicator color={tint} /> : null}
+          </View>
+        </View>
+      );
+    },
+    [border, busyById, onApprove, onOverride, overrideScores, theme, tint],
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Organizer Review' }} />
+      <ThemedView style={styles.container}>
+        <View style={styles.header}>
+          <ThemedText type="title">Review Queue</ThemedText>
+          <ThemedText style={styles.hint}>
+            Enter organizer code to load flagged submissions.
+          </ThemedText>
+        </View>
+
+        <View style={styles.codeRow}>
+          <TextInput
+            value={organizerCode}
+            onChangeText={setOrganizerCode}
+            placeholder="Organizer code"
+            placeholderTextColor={border}
+            autoCapitalize="none"
+            autoCorrect={false}
+            secureTextEntry
+            style={[
+              styles.codeInput,
+              { borderColor: border, color: Colors[theme].text },
+            ]}
+          />
+          <Pressable
+            onPress={loadQueue}
+            disabled={!canLoad || isLoading}
+            style={({ pressed }) => [
+              styles.loadButton,
+              { backgroundColor: canLoad && !isLoading ? tint : border },
+              pressed && canLoad && !isLoading ? styles.buttonPressed : null,
+            ]}
+          >
+            <ThemedText type="defaultSemiBold" style={styles.loadText}>
+              {isLoading ? 'Loading…' : 'Load'}
+            </ThemedText>
+          </Pressable>
+        </View>
+
+        {error ? (
+          <ThemedText style={[styles.errorText, { color: tint }]}>
+            {error}
+          </ThemedText>
+        ) : null}
+
+        {isLoading ? (
+          <View style={styles.loadingBox}>
+            <ActivityIndicator color={tint} />
+            <ThemedText style={styles.hint}>Fetching review queue…</ThemedText>
+          </View>
+        ) : rows.length === 0 && canLoad ? (
+          <View style={styles.emptyBox}>
+            <ThemedText type="subtitle">Queue clear</ThemedText>
+            <ThemedText style={styles.hint}>
+              No flagged submissions right now.
+            </ThemedText>
+          </View>
+        ) : (
+          <FlatList
+            data={rows}
+            keyExtractor={(r) => r.id}
+            renderItem={renderItem}
+            contentContainerStyle={styles.list}
+            refreshing={isLoading}
+            onRefresh={loadQueue}
+          />
+        )}
+      </ThemedView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  header: { gap: 6, marginBottom: 12 },
+  hint: { opacity: 0.85 },
+  errorText: { marginTop: 8, opacity: 0.95 },
+  codeRow: { flexDirection: 'row', gap: 10, alignItems: 'center' },
+  codeInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  loadButton: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+  },
+  loadText: { color: 'white' },
+  loadingBox: { marginTop: 18, gap: 10, alignItems: 'center' },
+  emptyBox: { marginTop: 18, gap: 6, alignItems: 'center' },
+  list: { paddingVertical: 12, gap: 12 },
+  card: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 14,
+    gap: 10,
+  },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+  meta: { opacity: 0.75 },
+  body: { opacity: 0.95, lineHeight: 20 },
+  row: { flexDirection: 'row', gap: 8, flexWrap: 'wrap' },
+  actions: { flexDirection: 'row', gap: 10, alignItems: 'center', flexWrap: 'wrap' },
+  button: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  buttonPressed: { opacity: 0.85, transform: [{ scale: 0.99 }] },
+  overrideBox: { flexDirection: 'row', gap: 10, alignItems: 'center' },
+  input: {
+    minWidth: 120,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+});
+

--- a/app/organizer/review.tsx
+++ b/app/organizer/review.tsx
@@ -13,6 +13,7 @@ import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { toAppError } from '@/lib/app-error';
 import { organizerJson } from '@/lib/organizer-api';
 
 type Submission = {
@@ -66,7 +67,7 @@ export default function OrganizerReviewDashboard() {
       );
       setRows(Array.isArray(data) ? data : []);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load review queue.');
+      setError(toAppError(e).message ?? 'Failed to load review queue.');
     } finally {
       setIsLoading(false);
     }
@@ -96,7 +97,7 @@ export default function OrganizerReviewDashboard() {
         setRows((prev) => prev.filter((r) => r.id !== row.id));
       } catch (e) {
         setError(
-          e instanceof Error ? e.message : 'Approve failed. Please try again.',
+          toAppError(e).message ?? 'Approve failed. Please try again.',
         );
       } finally {
         setBusy(row.id, false);
@@ -110,8 +111,8 @@ export default function OrganizerReviewDashboard() {
       if (!organizerCode.trim()) return;
       const raw = (overrideScores[row.id] ?? '').trim();
       const score = Number(raw);
-      if (!Number.isFinite(score) || score < 0) {
-        setError('Enter a valid non-negative score to override.');
+      if (!Number.isFinite(score) || !Number.isInteger(score) || score < 0) {
+        setError('Enter a valid non-negative whole number to override.');
         return;
       }
 
@@ -130,7 +131,7 @@ export default function OrganizerReviewDashboard() {
         setRows((prev) => prev.filter((r) => r.id !== row.id));
       } catch (e) {
         setError(
-          e instanceof Error ? e.message : 'Override failed. Please try again.',
+          toAppError(e).message ?? 'Override failed. Please try again.',
         );
       } finally {
         setBusy(row.id, false);

--- a/app/organizer/review.tsx
+++ b/app/organizer/review.tsx
@@ -327,11 +327,20 @@ const styles = StyleSheet.create({
     padding: 14,
     gap: 10,
   },
-  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
   meta: { opacity: 0.75 },
   body: { opacity: 0.95, lineHeight: 20 },
   row: { flexDirection: 'row', gap: 8, flexWrap: 'wrap' },
-  actions: { flexDirection: 'row', gap: 10, alignItems: 'center', flexWrap: 'wrap' },
+  actions: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
   button: {
     borderWidth: 1,
     borderRadius: 999,
@@ -349,4 +358,3 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
 });
-

--- a/app/organizer/review.tsx
+++ b/app/organizer/review.tsx
@@ -96,9 +96,7 @@ export default function OrganizerReviewDashboard() {
         );
         setRows((prev) => prev.filter((r) => r.id !== row.id));
       } catch (e) {
-        setError(
-          toAppError(e).message ?? 'Approve failed. Please try again.',
-        );
+        setError(toAppError(e).message ?? 'Approve failed. Please try again.');
       } finally {
         setBusy(row.id, false);
       }
@@ -130,9 +128,7 @@ export default function OrganizerReviewDashboard() {
         );
         setRows((prev) => prev.filter((r) => r.id !== row.id));
       } catch (e) {
-        setError(
-          toAppError(e).message ?? 'Override failed. Please try again.',
-        );
+        setError(toAppError(e).message ?? 'Override failed. Please try again.');
       } finally {
         setBusy(row.id, false);
       }

--- a/backend/routes/organizer.py
+++ b/backend/routes/organizer.py
@@ -81,7 +81,8 @@ def approve_review_queue_item(queue_id: str) -> Dict[str, Any]:
         raise HTTPException(status_code=400, detail="Queue item is missing claude_score")
 
     rationale = (queue_row.get("claude_rationale") or "Organizer approved").strip() or "Organizer approved"
-    confidence = float(queue_row.get("confidence") or 1.0)
+    queue_confidence = queue_row.get("confidence")
+    confidence = 1.0 if queue_confidence is None else float(queue_confidence)
 
     _finalize_score(
         supabase,

--- a/backend/routes/organizer.py
+++ b/backend/routes/organizer.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from auth.organizer import require_organizer
 from services import get_supabase
-from services.scoring import score_submission
+from services.scoring import score_submission, _finalize_score
 
 router = APIRouter(dependencies=[Depends(require_organizer)])
 
@@ -15,15 +15,115 @@ router = APIRouter(dependencies=[Depends(require_organizer)])
 @router.get("/review-queue")
 def list_review_queue() -> Any:
     supabase = get_supabase()
-    # Keep it lightweight: return raw queue rows ordered newest first.
+    # Join submissions so organizer UI can display submission content per row.
     return (
         supabase.table("review_queue")
-        .select("*")
+        .select(
+            "id,submission_id,claude_score,claude_rationale,confidence,created_at,"
+            "submission:submissions(id,task_id,team_id,text_answer,photo_url,status,score,confidence,rationale,gpt4o_description,created_at)"
+        )
         .order("created_at", desc=True)
         .execute()
         .data
         or []
     )
+
+
+class ReviewActionOk(BaseModel):
+    submission_id: str
+    status: str
+    score: int
+
+
+def _get_queue_row_or_404(queue_id: str) -> Dict[str, Any]:
+    supabase = get_supabase()
+    row = (
+        supabase.table("review_queue")
+        .select("id,submission_id,claude_score,claude_rationale,confidence,created_at")
+        .eq("id", queue_id)
+        .maybe_single()
+        .execute()
+        .data
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Review queue item not found")
+    return row
+
+
+def _get_submission_or_404(submission_id: str) -> Dict[str, Any]:
+    supabase = get_supabase()
+    row = (
+        supabase.table("submissions")
+        .select("id,team_id,status,score")
+        .eq("id", submission_id)
+        .maybe_single()
+        .execute()
+        .data
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    return row
+
+
+class OverrideIn(BaseModel):
+    score: int = Field(ge=0)
+    rationale: Optional[str] = None
+
+
+@router.post("/review-queue/{queue_id}/approve")
+def approve_review_queue_item(queue_id: str) -> Dict[str, Any]:
+    supabase = get_supabase()
+    queue_row = _get_queue_row_or_404(queue_id)
+    submission = _get_submission_or_404(queue_row["submission_id"])
+
+    suggested = queue_row.get("claude_score")
+    if suggested is None:
+        raise HTTPException(status_code=400, detail="Queue item is missing claude_score")
+
+    rationale = (queue_row.get("claude_rationale") or "Organizer approved").strip() or "Organizer approved"
+    confidence = float(queue_row.get("confidence") or 1.0)
+
+    _finalize_score(
+        supabase,
+        submission_id=submission["id"],
+        team_id=submission["team_id"],
+        score=int(suggested),
+        confidence=confidence,
+        rationale=rationale,
+        status="reviewed",
+        ai_result={"mode": "organizer_approve", "queue_id": queue_id},
+    )
+
+    # Remove from queue after decision.
+    supabase.table("review_queue").delete().eq("id", queue_id).execute()
+    return {"submission_id": submission["id"], "status": "reviewed", "score": int(suggested)}
+
+
+@router.post("/review-queue/{queue_id}/override")
+def override_review_queue_item(queue_id: str, payload: OverrideIn) -> Dict[str, Any]:
+    supabase = get_supabase()
+    queue_row = _get_queue_row_or_404(queue_id)
+    submission = _get_submission_or_404(queue_row["submission_id"])
+
+    rationale = (payload.rationale or "").strip() or "Organizer override"
+    _finalize_score(
+        supabase,
+        submission_id=submission["id"],
+        team_id=submission["team_id"],
+        score=int(payload.score),
+        confidence=1.0,
+        rationale=rationale,
+        status="reviewed",
+        ai_result={
+            "mode": "organizer_override",
+            "queue_id": queue_id,
+            "suggested_score": queue_row.get("claude_score"),
+            "suggested_rationale": queue_row.get("claude_rationale"),
+        },
+    )
+
+    supabase.table("review_queue").delete().eq("id", queue_id).execute()
+    return {"submission_id": submission["id"], "status": "reviewed", "score": int(payload.score)}
 
 
 class RescoreIn(BaseModel):

--- a/lib/organizer-api.ts
+++ b/lib/organizer-api.ts
@@ -1,7 +1,9 @@
 import { apiUrl } from '@/lib/api';
 import { httpJson, type HttpJsonInit } from '@/lib/http';
 
-export function organizerHeaders(organizerCode: string): Record<string, string> {
+export function organizerHeaders(
+  organizerCode: string,
+): Record<string, string> {
   return {
     'X-Organizer-Code': organizerCode.trim(),
   };
@@ -23,4 +25,3 @@ export async function organizerJson<T>(
     },
   });
 }
-

--- a/lib/organizer-api.ts
+++ b/lib/organizer-api.ts
@@ -1,0 +1,26 @@
+import { apiUrl } from '@/lib/api';
+import { httpJson, type HttpJsonInit } from '@/lib/http';
+
+export function organizerHeaders(organizerCode: string): Record<string, string> {
+  return {
+    'X-Organizer-Code': organizerCode.trim(),
+  };
+}
+
+export async function organizerJson<T>(
+  path: string,
+  organizerCode: string,
+  init: HttpJsonInit = {},
+): Promise<T> {
+  const code = organizerCode.trim();
+  if (!code) throw new Error('Missing organizer code.');
+
+  return await httpJson<T>(apiUrl(path), {
+    ...init,
+    headers: {
+      ...(init.headers ?? {}),
+      ...organizerHeaders(code),
+    },
+  });
+}
+


### PR DESCRIPTION
# What 
Organizers enter their code to load flagged submissions from the review queue. Each card shows the submission content, Claude's suggested score, and rationale. Organizers can approve the suggested score or enter a custom override. Both actions finalize the score, update the team total, and remove the row from the queue. 

# Why
Claude flags low-confidence submissions. The UI view with the submission review me means organizers are making a quicker, just as informed decision than if they had done completely manual