### PR TITLE
add settings tab and organizer prefill

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -35,6 +35,15 @@ export default function TabLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="gearshape.fill" color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -53,10 +53,6 @@ export default function RootLayout() {
         <RoleProvider>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen
-              name="modal"
-              options={{ presentation: 'modal', title: 'Modal' }}
-            />
           </Stack>
           <StatusBar style="auto" />
         </RoleProvider>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -53,6 +53,10 @@ export default function RootLayout() {
         <RoleProvider>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen
+              name="modal"
+              options={{ presentation: 'modal', title: 'Modal' }}
+            />
           </Stack>
           <StatusBar style="auto" />
         </RoleProvider>

--- a/app/organizer/review.tsx
+++ b/app/organizer/review.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -13,6 +13,7 @@ import { Stack } from 'expo-router';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
 import { toAppError } from '@/lib/app-error';
 import { organizerJson } from '@/lib/organizer-api';
+import { useRole } from '@/lib/role-context';
 
 type Submission = {
   id: string;
@@ -41,6 +42,13 @@ type ReviewQueueRow = {
 export default function OrganizerReviewDashboard() {
   const { colors, textColor, backgroundColor, tint, border } = useAppTheme();
 
+  const {
+    role,
+    organizerCode: sessionOrganizerCode,
+    setOrganizerCode: setSessionOrganizerCode,
+    setRole,
+  } = useRole();
+
   const [organizerCode, setOrganizerCode] = useState('');
   const [rows, setRows] = useState<ReviewQueueRow[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -51,6 +59,29 @@ export default function OrganizerReviewDashboard() {
   const [busyById, setBusyById] = useState<Record<string, boolean>>({});
 
   const canLoad = useMemo(() => Boolean(organizerCode.trim()), [organizerCode]);
+  const didAutoLoadRef = useRef(false);
+
+  useEffect(() => {
+    // If we entered organizer mode from Settings, pre-fill this screen.
+    if (!organizerCode.trim() && sessionOrganizerCode.trim()) {
+      setOrganizerCode(sessionOrganizerCode.trim());
+    }
+  }, [organizerCode, sessionOrganizerCode]);
+
+  useEffect(() => {
+    // Keep session state in sync while typing (session-only; not persisted).
+    const trimmed = organizerCode.trim();
+    if (trimmed && trimmed !== sessionOrganizerCode.trim()) {
+      if (role !== 'organizer') setRole('organizer');
+      setSessionOrganizerCode(trimmed);
+    }
+  }, [
+    organizerCode,
+    role,
+    sessionOrganizerCode,
+    setRole,
+    setSessionOrganizerCode,
+  ]);
 
   const loadQueue = useCallback(async () => {
     if (!organizerCode.trim()) return;
@@ -74,6 +105,16 @@ export default function OrganizerReviewDashboard() {
     setRows([]);
     setError(null);
   }, [organizerCode]);
+
+  useEffect(() => {
+    // Smooth UX: if we arrive with a session code, auto-load once.
+    if (!didAutoLoadRef.current && canLoad) {
+      didAutoLoadRef.current = true;
+      loadQueue().catch(() => {
+        // Screen shows error state already.
+      });
+    }
+  }, [canLoad, loadQueue]);
 
   const setBusy = useCallback((id: string, v: boolean) => {
     setBusyById((prev) => ({ ...prev, [id]: v }));

--- a/app/organizer/review.tsx
+++ b/app/organizer/review.tsx
@@ -59,22 +59,28 @@ export default function OrganizerReviewDashboard() {
   const [busyById, setBusyById] = useState<Record<string, boolean>>({});
 
   const canLoad = useMemo(() => Boolean(organizerCode.trim()), [organizerCode]);
+  const didPrefillOrganizerCodeRef = useRef(false);
   const didAutoLoadRef = useRef(false);
 
   useEffect(() => {
-    // If we entered organizer mode from Settings, pre-fill this screen.
-    if (!organizerCode.trim() && sessionOrganizerCode.trim()) {
-      setOrganizerCode(sessionOrganizerCode.trim());
-    }
-  }, [organizerCode, sessionOrganizerCode]);
+    if (didPrefillOrganizerCodeRef.current) return;
+    const trimmed = sessionOrganizerCode.trim();
+    if (!trimmed) return;
+    didPrefillOrganizerCodeRef.current = true;
+    setOrganizerCode(trimmed);
+  }, [sessionOrganizerCode]);
 
   useEffect(() => {
     // Keep session state in sync while typing (session-only; not persisted).
     const trimmed = organizerCode.trim();
-    if (trimmed && trimmed !== sessionOrganizerCode.trim()) {
+    const sessionTrimmed = sessionOrganizerCode.trim();
+    if (trimmed === sessionTrimmed) return;
+    if (trimmed) {
       if (role !== 'organizer') setRole('organizer');
       setSessionOrganizerCode(trimmed);
+      return;
     }
+    setSessionOrganizerCode('');
   }, [
     organizerCode,
     role,


### PR DESCRIPTION
# What
New settings tab at bottom of screen, reads/writes organizer session state via useRole(). Prefills organizer code input from session organizer code and keeps session in sync as user types.

# Why
The organizer review dashboard needs the code on every request and storing it in session means organizers enter it once and it persists across screens instead of re-entering it on every action.