### PR TITLE
UX submission polish

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,5 +1,4 @@
 import { Tabs } from 'expo-router';
-import React from 'react';
 
 import { HapticTab } from '@/components/haptic-tab';
 import { IconSymbol } from '@/components/ui/icon-symbol';
@@ -42,6 +41,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => (
             <IconSymbol size={28} name="gearshape.fill" color={color} />
           ),
+        }}
+      />
+      <Tabs.Screen
+        name="organizer"
+        options={{
+          // Hidden route used for organizer tools.
+          href: null,
         }}
       />
     </Tabs>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -212,7 +212,8 @@ export default function TaskListScreen() {
               status === 'auto_approved' ||
               status === 'approved' ||
               status === 'reviewed';
-            const isSubmittedButNotComplete = Boolean(submission) && !isCompleted;
+            const isSubmittedButNotComplete =
+              Boolean(submission) && !isCompleted;
             const isDisabled = isCompleted;
 
             return (
@@ -256,7 +257,7 @@ export default function TaskListScreen() {
                     ) : isNew ? (
                       <AppChip>New</AppChip>
                     ) : null}
-                    <AppChip tone="accent">{item.max_points} pts</AppChip>
+                    <AppChip tone="accent">{`${item.max_points} pts`}</AppChip>
                   </View>
                 </View>
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
 import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ScreenState } from '@/components/screen-state';
 import { SapsutLogo } from '@/components/sapsut-logo';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
 import { apiUrl } from '@/lib/api';
 import { httpJson } from '@/lib/http';
+import { getSavedTeamId } from '@/lib/team-session';
 
 type Task = {
   id: string | number;
@@ -18,6 +20,14 @@ type Task = {
   opens_at?: string | null;
   closes_at?: string | null;
 };
+
+type SubmissionListItem = {
+  id: string;
+  task_id?: string | null;
+  team_id?: string | null;
+};
+
+const NEW_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 function isTaskOpenNow(task: Task, nowMs: number): boolean {
   const opensMs = task.opens_at ? Date.parse(task.opens_at) : NaN;
@@ -42,11 +52,16 @@ function formatSubmissionType(type: Task['type']): string {
 
 export default function TaskListScreen() {
   const { textColor, backgroundColor, border, tint } = useAppTheme();
+  const insets = useSafeAreaInsets();
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<unknown>(undefined);
+  const [teamId, setTeamId] = useState<string | null>(null);
+  const [completedTaskIds, setCompletedTaskIds] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const fetchTasks = useCallback(async () => {
     // Note: This does not cancel in-flight requests on unmount. For production,
@@ -71,6 +86,44 @@ export default function TaskListScreen() {
       mounted = false;
     };
   }, [fetchTasks]);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const saved = await getSavedTeamId();
+      if (!mounted) return;
+      setTeamId(saved);
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!teamId?.trim()) {
+      setCompletedTaskIds(new Set());
+      return;
+    }
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await httpJson<SubmissionListItem[]>(
+          apiUrl(`/submissions/?team_id=${encodeURIComponent(teamId.trim())}`),
+        );
+        const next = new Set<string>();
+        for (const s of Array.isArray(list) ? list : []) {
+          const tid = typeof s?.task_id === 'string' ? s.task_id.trim() : '';
+          if (tid) next.add(tid);
+        }
+        if (mounted) setCompletedTaskIds(next);
+      } catch {
+        if (mounted) setCompletedTaskIds(new Set());
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [teamId]);
 
   const onRetry = useCallback(async () => {
     setIsLoading(true);
@@ -109,7 +162,7 @@ export default function TaskListScreen() {
       loadingLabel="Loading tasks…"
     >
       <View style={[screenStyles.container, { backgroundColor }]}>
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: Math.max(insets.top, 8) }]}>
           <View style={styles.headerTopRow}>
             <SapsutLogo width={120} height={54} />
           </View>
@@ -131,6 +184,14 @@ export default function TaskListScreen() {
           refreshing={isRefreshing}
           onRefresh={onRefresh}
           renderItem={({ item }) => {
+            const nowMs = Date.now();
+            const opensMs = item.opens_at ? Date.parse(item.opens_at) : NaN;
+            const isNew =
+              Number.isFinite(opensMs) &&
+              opensMs <= nowMs &&
+              nowMs - opensMs <= NEW_WINDOW_MS;
+            const isCompleted = completedTaskIds.has(String(item.id));
+
             return (
               <Pressable
                 onPress={() =>
@@ -155,16 +216,43 @@ export default function TaskListScreen() {
                   >
                     {item.title}
                   </Text>
-                  <View style={[styles.pill, { borderColor: tint }]}>
-                    <Text
-                      style={[
-                        textStyles.defaultSemiBold,
-                        styles.pillText,
-                        { color: tint },
-                      ]}
-                    >
-                      {item.max_points} pts
-                    </Text>
+                  <View style={styles.pillRow}>
+                    {isCompleted ? (
+                      <View style={[styles.pill, { borderColor: tint }]}>
+                        <Text
+                          style={[
+                            textStyles.defaultSemiBold,
+                            styles.pillText,
+                            { color: tint },
+                          ]}
+                        >
+                          Completed
+                        </Text>
+                      </View>
+                    ) : isNew ? (
+                      <View style={[styles.pill, { borderColor: border }]}>
+                        <Text
+                          style={[
+                            textStyles.defaultSemiBold,
+                            styles.pillText,
+                            { color: textColor },
+                          ]}
+                        >
+                          New
+                        </Text>
+                      </View>
+                    ) : null}
+                    <View style={[styles.pill, { borderColor: tint }]}>
+                      <Text
+                        style={[
+                          textStyles.defaultSemiBold,
+                          styles.pillText,
+                          { color: tint },
+                        ]}
+                      >
+                        {item.max_points} pts
+                      </Text>
+                    </View>
                   </View>
                 </View>
 
@@ -270,6 +358,11 @@ const styles = StyleSheet.create({
   },
   cardTitle: {
     flex: 1,
+  },
+  pillRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
   },
   pill: {
     borderWidth: 1,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ScreenState } from '@/components/screen-state';
 import { SapsutLogo } from '@/components/sapsut-logo';
+import { AppCard, AppChip } from '@/components/ui';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
 import { apiUrl } from '@/lib/api';
 import { httpJson } from '@/lib/http';
@@ -25,9 +26,15 @@ type SubmissionListItem = {
   id: string;
   task_id?: string | null;
   team_id?: string | null;
+  status?: string | null;
 };
 
 const NEW_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function normalizeStatus(raw: unknown): string {
+  const s = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  return s || 'pending';
+}
 
 function isTaskOpenNow(task: Task, nowMs: number): boolean {
   const opensMs = task.opens_at ? Date.parse(task.opens_at) : NaN;
@@ -50,8 +57,12 @@ function formatSubmissionType(type: Task['type']): string {
   }
 }
 
+function submissionTone(type: Task['type']): 'default' | 'accent' {
+  return type === 'photo' || type === 'combo' ? 'accent' : 'default';
+}
+
 export default function TaskListScreen() {
-  const { textColor, backgroundColor, border, tint } = useAppTheme();
+  const { textColor, backgroundColor } = useAppTheme();
   const insets = useSafeAreaInsets();
 
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -59,9 +70,9 @@ export default function TaskListScreen() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<unknown>(undefined);
   const [teamId, setTeamId] = useState<string | null>(null);
-  const [completedTaskIds, setCompletedTaskIds] = useState<Set<string>>(
-    () => new Set(),
-  );
+  const [taskSubmissionByTaskId, setTaskSubmissionByTaskId] = useState<
+    Record<string, { id: string; status: string }>
+  >({});
 
   const fetchTasks = useCallback(async () => {
     // Note: This does not cancel in-flight requests on unmount. For production,
@@ -101,7 +112,7 @@ export default function TaskListScreen() {
 
   useEffect(() => {
     if (!teamId?.trim()) {
-      setCompletedTaskIds(new Set());
+      setTaskSubmissionByTaskId({});
       return;
     }
     let mounted = true;
@@ -110,14 +121,17 @@ export default function TaskListScreen() {
         const list = await httpJson<SubmissionListItem[]>(
           apiUrl(`/submissions/?team_id=${encodeURIComponent(teamId.trim())}`),
         );
-        const next = new Set<string>();
+        const next: Record<string, { id: string; status: string }> = {};
         for (const s of Array.isArray(list) ? list : []) {
           const tid = typeof s?.task_id === 'string' ? s.task_id.trim() : '';
-          if (tid) next.add(tid);
+          if (!tid) continue;
+          // The backend returns newest-first; keep the first (latest) submission per task.
+          if (next[tid]) continue;
+          next[tid] = { id: String(s.id), status: normalizeStatus(s.status) };
         }
-        if (mounted) setCompletedTaskIds(next);
+        if (mounted) setTaskSubmissionByTaskId(next);
       } catch {
-        if (mounted) setCompletedTaskIds(new Set());
+        if (mounted) setTaskSubmissionByTaskId({});
       }
     })();
     return () => {
@@ -190,69 +204,59 @@ export default function TaskListScreen() {
               Number.isFinite(opensMs) &&
               opensMs <= nowMs &&
               nowMs - opensMs <= NEW_WINDOW_MS;
-            const isCompleted = completedTaskIds.has(String(item.id));
+
+            const submission = taskSubmissionByTaskId[String(item.id)];
+            const status = submission?.status ?? null;
+            const isInReview = status === 'flagged';
+            const isCompleted =
+              status === 'auto_approved' ||
+              status === 'approved' ||
+              status === 'reviewed';
+            const isSubmittedButNotComplete = Boolean(submission) && !isCompleted;
+            const isDisabled = isCompleted;
 
             return (
-              <Pressable
-                onPress={() =>
-                  router.push({
-                    pathname: '/tasks/[id]/submit',
-                    params: { id: String(item.id) },
-                  })
+              <AppCard
+                onPress={
+                  isDisabled
+                    ? undefined
+                    : isSubmittedButNotComplete
+                      ? () =>
+                          router.push({
+                            pathname: '/submissions/[id]',
+                            params: { id: submission?.id ?? '' },
+                          })
+                      : () =>
+                          router.push({
+                            pathname: '/tasks/[id]/submit',
+                            params: { id: String(item.id) },
+                          })
                 }
-                style={({ pressed }) => [
-                  styles.card,
-                  { borderColor: border },
-                  pressed ? styles.cardPressed : null,
-                ]}
+                disabled={isDisabled}
+                style={[styles.card, isDisabled ? styles.cardDisabled : null]}
+                contentStyle={styles.cardContent}
               >
                 <View style={styles.cardHeader}>
                   <Text
                     style={[
                       textStyles.subtitle,
                       styles.cardTitle,
-                      { color: textColor },
+                      { color: textColor, opacity: isDisabled ? 0.45 : 1 },
                     ]}
                   >
                     {item.title}
                   </Text>
-                  <View style={styles.pillRow}>
+                  <View style={styles.chipRow}>
                     {isCompleted ? (
-                      <View style={[styles.pill, { borderColor: tint }]}>
-                        <Text
-                          style={[
-                            textStyles.defaultSemiBold,
-                            styles.pillText,
-                            { color: tint },
-                          ]}
-                        >
-                          Completed
-                        </Text>
-                      </View>
+                      <AppChip tone="accent" selected>
+                        Completed
+                      </AppChip>
+                    ) : isInReview ? (
+                      <AppChip tone="danger">In review</AppChip>
                     ) : isNew ? (
-                      <View style={[styles.pill, { borderColor: border }]}>
-                        <Text
-                          style={[
-                            textStyles.defaultSemiBold,
-                            styles.pillText,
-                            { color: textColor },
-                          ]}
-                        >
-                          New
-                        </Text>
-                      </View>
+                      <AppChip>New</AppChip>
                     ) : null}
-                    <View style={[styles.pill, { borderColor: tint }]}>
-                      <Text
-                        style={[
-                          textStyles.defaultSemiBold,
-                          styles.pillText,
-                          { color: tint },
-                        ]}
-                      >
-                        {item.max_points} pts
-                      </Text>
-                    </View>
+                    <AppChip tone="accent">{item.max_points} pts</AppChip>
                   </View>
                 </View>
 
@@ -261,34 +265,19 @@ export default function TaskListScreen() {
                     style={[
                       textStyles.default,
                       styles.description,
-                      { color: textColor },
+                      { color: textColor, opacity: isDisabled ? 0.45 : 0.9 },
                     ]}
                   >
                     {item.description}
                   </Text>
                 ) : null}
 
-                <View style={styles.metaRow}>
-                  <Text
-                    style={[
-                      textStyles.defaultSemiBold,
-                      styles.metaLabel,
-                      { color: textColor },
-                    ]}
-                  >
-                    Submission:
-                  </Text>
-                  <Text
-                    style={[
-                      textStyles.default,
-                      styles.metaValue,
-                      { color: textColor },
-                    ]}
-                  >
+                <View style={styles.submissionRow}>
+                  <AppChip tone={submissionTone(item.type)}>
                     {formatSubmissionType(item.type)}
-                  </Text>
+                  </AppChip>
                 </View>
-              </Pressable>
+              </AppCard>
             );
           }}
           ListEmptyComponent={
@@ -341,14 +330,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   card: {
-    borderWidth: 1,
     borderRadius: 16,
+  },
+  cardDisabled: {
+    opacity: 0.65,
+  },
+  cardContent: {
     padding: 14,
     gap: 10,
-  },
-  cardPressed: {
-    opacity: 0.85,
-    transform: [{ scale: 0.99 }],
   },
   cardHeader: {
     flexDirection: 'row',
@@ -359,33 +348,17 @@ const styles = StyleSheet.create({
   cardTitle: {
     flex: 1,
   },
-  pillRow: {
+  chipRow: {
     flexDirection: 'row',
     gap: 8,
     alignItems: 'center',
   },
-  pill: {
-    borderWidth: 1,
-    borderRadius: 999,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-  },
-  pillText: {
-    fontSize: 13,
-  },
   description: {
     opacity: 0.9,
   },
-  metaRow: {
+  submissionRow: {
     flexDirection: 'row',
-    gap: 6,
     alignItems: 'center',
-  },
-  metaLabel: {
-    opacity: 0.85,
-  },
-  metaValue: {
-    opacity: 0.85,
   },
   empty: {
     alignItems: 'center',

--- a/app/(tabs)/leaderboard.tsx
+++ b/app/(tabs)/leaderboard.tsx
@@ -1,10 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import {
-  FlatList,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -213,7 +208,11 @@ export default function LeaderboardScreen() {
               >
                 Once teams join and score points, they’ll show up here.
               </Text>
-              <AppButton tone="secondary" onPress={onRetry} style={styles.retryButton}>
+              <AppButton
+                tone="secondary"
+                onPress={onRetry}
+                style={styles.retryButton}
+              >
                 Refresh
               </AppButton>
             </View>

--- a/app/(tabs)/leaderboard.tsx
+++ b/app/(tabs)/leaderboard.tsx
@@ -8,6 +8,7 @@ import {
   type PressableStateCallbackType,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ScreenState } from '@/components/screen-state';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
@@ -31,6 +32,7 @@ function toScore(team: LeaderboardTeam): number {
 
 export default function LeaderboardScreen() {
   const { textColor, backgroundColor, tint, border } = useAppTheme();
+  const insets = useSafeAreaInsets();
 
   const [teams, setTeams] = useState<LeaderboardTeam[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -135,7 +137,7 @@ export default function LeaderboardScreen() {
       loadingLabel="Loading leaderboard…"
     >
       <View style={[screenStyles.container, { backgroundColor }]}>
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: Math.max(insets.top, 8) }]}>
           <Text style={[textStyles.title, { color: textColor }]}>
             Leaderboard
           </Text>

--- a/app/(tabs)/leaderboard.tsx
+++ b/app/(tabs)/leaderboard.tsx
@@ -1,16 +1,15 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   FlatList,
-  Pressable,
   StyleSheet,
   Text,
   View,
-  type PressableStateCallbackType,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ScreenState } from '@/components/screen-state';
+import { AppButton, AppCard } from '@/components/ui';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
 import { apiUrl } from '@/lib/api';
 import { httpJson } from '@/lib/http';
@@ -31,7 +30,7 @@ function toScore(team: LeaderboardTeam): number {
 }
 
 export default function LeaderboardScreen() {
-  const { textColor, backgroundColor, tint, border } = useAppTheme();
+  const { textColor, backgroundColor, tint } = useAppTheme();
   const insets = useSafeAreaInsets();
 
   const [teams, setTeams] = useState<LeaderboardTeam[]>([]);
@@ -159,7 +158,7 @@ export default function LeaderboardScreen() {
           onRefresh={onRefresh}
           renderItem={({ item, index }) => {
             return (
-              <View style={[styles.row, { borderColor: border }]}>
+              <AppCard style={styles.row} contentStyle={styles.rowContent}>
                 <View style={styles.rowLeft}>
                   <Text
                     style={[
@@ -176,6 +175,7 @@ export default function LeaderboardScreen() {
                       styles.teamName,
                       { color: textColor },
                     ]}
+                    numberOfLines={1}
                   >
                     {item.name || 'Unnamed team'}
                   </Text>
@@ -190,7 +190,7 @@ export default function LeaderboardScreen() {
                 >
                   {toScore(item)}
                 </Text>
-              </View>
+              </AppCard>
             );
           }}
           ListEmptyComponent={
@@ -213,18 +213,9 @@ export default function LeaderboardScreen() {
               >
                 Once teams join and score points, they’ll show up here.
               </Text>
-              <Pressable
-                onPress={onRetry}
-                style={({ pressed }: PressableStateCallbackType) => [
-                  styles.retryButton,
-                  { borderColor: tint },
-                  pressed ? styles.retryButtonPressed : null,
-                ]}
-              >
-                <Text style={[textStyles.defaultSemiBold, { color: tint }]}>
-                  Refresh
-                </Text>
-              </Pressable>
+              <AppButton tone="secondary" onPress={onRetry} style={styles.retryButton}>
+                Refresh
+              </AppButton>
             </View>
           }
         />
@@ -250,8 +241,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   row: {
-    borderWidth: 1,
     borderRadius: 16,
+    overflow: 'hidden',
+  },
+  rowContent: {
     paddingVertical: 12,
     paddingHorizontal: 14,
     flexDirection: 'row',
@@ -289,14 +282,6 @@ const styles = StyleSheet.create({
     opacity: 0.85,
   },
   retryButton: {
-    borderWidth: 1,
-    borderRadius: 999,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
     marginTop: 4,
-  },
-  retryButtonPressed: {
-    opacity: 0.85,
-    transform: [{ scale: 0.99 }],
   },
 });

--- a/app/(tabs)/organizer.tsx
+++ b/app/(tabs)/organizer.tsx
@@ -1,0 +1,2 @@
+export { default } from '../organizer/review';
+

--- a/app/(tabs)/organizer.tsx
+++ b/app/(tabs)/organizer.tsx
@@ -1,2 +1,1 @@
 export { default } from '../organizer/review';
-

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -43,7 +43,7 @@ export default function SettingsScreen() {
     setIsModalOpen(false);
     setError(null);
     enterOrganizerMode(code);
-    router.push('/organizer/review');
+    router.push('/(tabs)/organizer');
   }, [codeDraft, enterOrganizerMode]);
 
   const onCancelOrganizer = useCallback(() => {
@@ -53,7 +53,7 @@ export default function SettingsScreen() {
 
   const onSwitchToParticipant = useCallback(() => {
     exitOrganizerMode();
-    router.replace('/(tabs)');
+    router.replace('/(tabs)/index');
   }, [exitOrganizerMode]);
 
   return (

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -53,7 +53,7 @@ export default function SettingsScreen() {
 
   const onSwitchToParticipant = useCallback(() => {
     exitOrganizerMode();
-    router.replace('/(tabs)/index');
+    router.replace('/(tabs)');
   }, [exitOrganizerMode]);
 
   return (

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ScreenState } from '@/components/screen-state';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
@@ -15,6 +16,7 @@ import { useRole } from '@/lib/role-context';
 
 export default function SettingsScreen() {
   const { textColor, backgroundColor, tint, border, colors } = useAppTheme();
+  const insets = useSafeAreaInsets();
 
   const { role, enterOrganizerMode, exitOrganizerMode } = useRole();
 
@@ -59,7 +61,7 @@ export default function SettingsScreen() {
       <View
         style={[screenStyles.container, styles.container, { backgroundColor }]}
       >
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: Math.max(insets.top, 8) }]}>
           <Text style={[textStyles.title, { color: textColor }]}>Settings</Text>
           <Text
             style={[textStyles.default, styles.subtitle, { color: textColor }]}

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -3,4 +3,3 @@ import { Redirect } from 'expo-router';
 export default function NotFound() {
   return <Redirect href="/(tabs)" />;
 }
-

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,0 +1,6 @@
+import { Redirect } from 'expo-router';
+
+export default function NotFound() {
+  return <Redirect href="/(tabs)" />;
+}
+

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,12 @@ import {
   JosefinSlab_600SemiBold,
 } from '@expo-google-fonts/josefin-slab';
 import { View } from 'react-native';
+import {
+  MD3DarkTheme,
+  MD3LightTheme,
+  PaperProvider,
+  configureFonts,
+} from 'react-native-paper';
 
 import { AppErrorBoundary } from '@/components/app-error-boundary';
 import { Colors } from '@/constants/theme';
@@ -47,15 +53,84 @@ export default function RootLayout() {
     );
   }
 
+  const paperTheme =
+    colorScheme === 'dark'
+      ? {
+          ...MD3DarkTheme,
+          colors: {
+            ...MD3DarkTheme.colors,
+            primary: Colors.dark.tint,
+            onPrimary: Colors.dark.background,
+            background: Colors.dark.background,
+            surface: Colors.dark.background,
+            onSurface: Colors.dark.text,
+            onBackground: Colors.dark.text,
+            outline: Colors.dark.icon,
+          },
+          fonts: configureFonts({
+            config: {
+              displayLarge: { fontFamily: 'JosefinSlab_600SemiBold' },
+              displayMedium: { fontFamily: 'JosefinSlab_600SemiBold' },
+              displaySmall: { fontFamily: 'JosefinSlab_600SemiBold' },
+              headlineLarge: { fontFamily: 'JosefinSlab_600SemiBold' },
+              headlineMedium: { fontFamily: 'JosefinSlab_600SemiBold' },
+              headlineSmall: { fontFamily: 'JosefinSlab_600SemiBold' },
+              titleLarge: { fontFamily: 'JosefinSans_600SemiBold' },
+              titleMedium: { fontFamily: 'JosefinSans_600SemiBold' },
+              titleSmall: { fontFamily: 'JosefinSans_600SemiBold' },
+              labelLarge: { fontFamily: 'JosefinSans_600SemiBold' },
+              labelMedium: { fontFamily: 'JosefinSans_600SemiBold' },
+              labelSmall: { fontFamily: 'JosefinSans_600SemiBold' },
+              bodyLarge: { fontFamily: 'JosefinSans_400Regular' },
+              bodyMedium: { fontFamily: 'JosefinSans_400Regular' },
+              bodySmall: { fontFamily: 'JosefinSans_400Regular' },
+            },
+          }),
+        }
+      : {
+          ...MD3LightTheme,
+          colors: {
+            ...MD3LightTheme.colors,
+            primary: Colors.light.tint,
+            onPrimary: Colors.light.background,
+            background: Colors.light.background,
+            surface: Colors.light.background,
+            onSurface: Colors.light.text,
+            onBackground: Colors.light.text,
+            outline: Colors.light.icon,
+          },
+          fonts: configureFonts({
+            config: {
+              displayLarge: { fontFamily: 'JosefinSlab_600SemiBold' },
+              displayMedium: { fontFamily: 'JosefinSlab_600SemiBold' },
+              displaySmall: { fontFamily: 'JosefinSlab_600SemiBold' },
+              headlineLarge: { fontFamily: 'JosefinSlab_600SemiBold' },
+              headlineMedium: { fontFamily: 'JosefinSlab_600SemiBold' },
+              headlineSmall: { fontFamily: 'JosefinSlab_600SemiBold' },
+              titleLarge: { fontFamily: 'JosefinSans_600SemiBold' },
+              titleMedium: { fontFamily: 'JosefinSans_600SemiBold' },
+              titleSmall: { fontFamily: 'JosefinSans_600SemiBold' },
+              labelLarge: { fontFamily: 'JosefinSans_600SemiBold' },
+              labelMedium: { fontFamily: 'JosefinSans_600SemiBold' },
+              labelSmall: { fontFamily: 'JosefinSans_600SemiBold' },
+              bodyLarge: { fontFamily: 'JosefinSans_400Regular' },
+              bodyMedium: { fontFamily: 'JosefinSans_400Regular' },
+              bodySmall: { fontFamily: 'JosefinSans_400Regular' },
+            },
+          }),
+        };
+
   return (
     <AppErrorBoundary>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <RoleProvider>
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          </Stack>
-          <StatusBar style="auto" />
-        </RoleProvider>
+        <PaperProvider theme={paperTheme}>
+          <RoleProvider>
+            <Stack>
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            </Stack>
+            <StatusBar style="auto" />
+          </RoleProvider>
+        </PaperProvider>
       </ThemeProvider>
     </AppErrorBoundary>
   );

--- a/app/submissions/[id].tsx
+++ b/app/submissions/[id].tsx
@@ -134,7 +134,8 @@ export default function SubmissionConfirmationScreen() {
   }, [error, fetchOnce, isLoading, isTerminal, submissionId]);
 
   const onBackToTasks = useCallback(() => {
-    router.replace('/(tabs)');
+    // Avoid routing to the group root (which can surface as a weird back label).
+    router.replace('/(tabs)/index');
   }, []);
 
   const title = useMemo(() => {
@@ -148,7 +149,9 @@ export default function SubmissionConfirmationScreen() {
 
   return (
     <>
-      <Stack.Screen options={{ title: 'Confirmation' }} />
+      <Stack.Screen
+        options={{ title: 'Confirmation', headerBackTitle: 'Tasks' }}
+      />
       <ScreenState
         isLoading={isLoading}
         error={error}

--- a/app/submissions/[id].tsx
+++ b/app/submissions/[id].tsx
@@ -150,7 +150,17 @@ export default function SubmissionConfirmationScreen() {
   return (
     <>
       <Stack.Screen
-        options={{ title: 'Confirmation', headerBackTitle: 'Tasks' }}
+        options={{
+          title: 'Confirmation',
+          headerBackTitle: 'Tasks',
+          headerLeft: () => (
+            <Pressable onPress={onBackToTasks} style={styles.headerBack}>
+              <Text style={[textStyles.defaultSemiBold, { color: tint }]}>
+                Back
+              </Text>
+            </Pressable>
+          ),
+        }}
       />
       <ScreenState
         isLoading={isLoading}
@@ -304,6 +314,10 @@ export default function SubmissionConfirmationScreen() {
 }
 
 const styles = StyleSheet.create({
+  headerBack: {
+    paddingHorizontal: 6,
+    paddingVertical: 6,
+  },
   content: {
     gap: 10,
   },

--- a/app/submissions/[id].tsx
+++ b/app/submissions/[id].tsx
@@ -135,7 +135,7 @@ export default function SubmissionConfirmationScreen() {
 
   const onBackToTasks = useCallback(() => {
     // Avoid routing to the group root (which can surface as a weird back label).
-    router.replace('/(tabs)/index');
+    router.replace('/(tabs)');
   }, []);
 
   const title = useMemo(() => {

--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -15,6 +15,7 @@ import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
 import { apiUrl } from '@/lib/api';
 import { httpJson } from '@/lib/http';
 import { uploadSubmissionPhoto } from '@/lib/storage';
+import { getSavedTeamId, saveTeamId } from '@/lib/team-session';
 
 type Task = {
   id: string | number;
@@ -49,6 +50,20 @@ export default function TaskSubmitScreen() {
   const [submitSuccessId, setSubmitSuccessId] = useState<string | null>(null);
 
   const taskId = String(id ?? '');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const saved = await getSavedTeamId();
+      if (!mounted) return;
+      if (saved && !teamId.trim()) setTeamId(saved);
+    })();
+    return () => {
+      mounted = false;
+    };
+    // Intentionally only runs once; don't override manual edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     // `expo-image-picker` does not reliably expose a camera-availability API across SDKs.
@@ -167,6 +182,7 @@ export default function TaskSubmitScreen() {
     setSubmitSuccessId(null);
 
     try {
+      await saveTeamId(teamId);
       let uploadedPath: string | null = photoPath;
 
       if (photoAsset && !uploadedPath) {
@@ -257,7 +273,7 @@ export default function TaskSubmitScreen() {
 
   return (
     <>
-      <Stack.Screen options={{ title: 'Submit' }} />
+      <Stack.Screen options={{ title: 'Submit', headerBackTitle: 'Tasks' }} />
       <View style={[screenStyles.container, { backgroundColor }]}>
         <View style={styles.content}>
           <Text style={[textStyles.title, { color: textColor }]}>
@@ -275,6 +291,17 @@ export default function TaskSubmitScreen() {
               <Text style={[textStyles.subtitle, { color: textColor }]}>
                 {task.title}
               </Text>
+              {task.description?.trim() ? (
+                <Text
+                  style={[
+                    textStyles.default,
+                    styles.description,
+                    { color: textColor },
+                  ]}
+                >
+                  {task.description}
+                </Text>
+              ) : null}
               <Text
                 style={[textStyles.default, styles.hint, { color: textColor }]}
               >
@@ -285,12 +312,23 @@ export default function TaskSubmitScreen() {
                   {task.type}
                 </Text>
               </Text>
+              <Text
+                style={[textStyles.default, styles.hint, { color: textColor }]}
+              >
+                Points:{' '}
+                <Text
+                  style={[textStyles.defaultSemiBold, { color: textColor }]}
+                >
+                  {task.max_points}
+                </Text>
+              </Text>
             </View>
           ) : (
             <Text
               style={[textStyles.default, styles.hint, { color: textColor }]}
             >
-              Couldn’t load task. (id: {taskId})
+              Couldn’t load this task. Pull to refresh the task list and try
+              again.
             </Text>
           )}
 
@@ -307,7 +345,7 @@ export default function TaskSubmitScreen() {
             <TextInput
               value={teamId}
               onChangeText={setTeamId}
-              placeholder="UUID of your team"
+              placeholder="Enter your team ID (we’ll remember it)"
               placeholderTextColor={border}
               autoCapitalize="none"
               autoCorrect={false}
@@ -501,10 +539,13 @@ export default function TaskSubmitScreen() {
 
 const styles = StyleSheet.create({
   content: {
-    gap: 10,
+    gap: 8,
   },
   taskHeader: {
     gap: 4,
+  },
+  description: {
+    opacity: 0.9,
   },
   hint: {
     opacity: 0.85,

--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -202,10 +202,11 @@ export default function TaskSubmitScreen() {
           photoAsset.fileName?.trim() ||
           `submission-${taskId}-${Date.now()}.jpg`;
         const type = photoAsset.mimeType?.trim() || 'image/jpeg';
-        fd.append(
-          'photo',
-          { uri: photoAsset.uri, name, type } as unknown as Blob,
-        );
+        fd.append('photo', {
+          uri: photoAsset.uri,
+          name,
+          type,
+        } as unknown as Blob);
       }
 
       const res = await fetch(apiUrl('/submissions/'), {
@@ -229,7 +230,9 @@ export default function TaskSubmitScreen() {
           body && typeof body === 'object'
             ? 'error' in body && typeof body.error === 'string' && body.error
               ? body.error
-              : 'detail' in body && typeof body.detail === 'string' && body.detail
+              : 'detail' in body &&
+                  typeof body.detail === 'string' &&
+                  body.detail
                 ? body.detail
                 : 'Submission failed. Please try again.'
             : 'Submission failed. Please try again.',
@@ -268,7 +271,7 @@ export default function TaskSubmitScreen() {
   }, [canSubmit, photoAsset, taskId, teamId, textAnswer]);
 
   const onBackToTasks = useCallback(() => {
-    router.replace('/(tabs)/index');
+    router.replace('/(tabs)');
   }, []);
 
   return (

--- a/app/tasks/[id]/submit.tsx
+++ b/app/tasks/[id]/submit.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -14,7 +15,6 @@ import { Image } from 'expo-image';
 import { screenStyles, textStyles, useAppTheme } from '@/lib/ui';
 import { apiUrl } from '@/lib/api';
 import { httpJson } from '@/lib/http';
-import { uploadSubmissionPhoto } from '@/lib/storage';
 import { getSavedTeamId, saveTeamId } from '@/lib/team-session';
 
 type Task = {
@@ -29,6 +29,14 @@ type CreateSubmissionOk = { submission_id: string; status: string };
 type CreateSubmissionError = { error: string; existing_submission_id?: string };
 type CreateSubmissionResponse = CreateSubmissionOk | CreateSubmissionError;
 
+function displayAssetLabel(asset: ImagePicker.ImagePickerAsset): string {
+  const name = asset.fileName?.trim();
+  if (name) return name;
+  const uri = asset.uri ?? '';
+  const last = uri.split('?')[0]?.split('#')[0]?.split('/').pop()?.trim();
+  return last || 'selected photo';
+}
+
 export default function TaskSubmitScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { colors, textColor, backgroundColor, border, tint } = useAppTheme();
@@ -41,8 +49,6 @@ export default function TaskSubmitScreen() {
   const [textAnswer, setTextAnswer] = useState('');
   const [photoAsset, setPhotoAsset] =
     useState<ImagePicker.ImagePickerAsset | null>(null);
-  const [photoPath, setPhotoPath] = useState<string | null>(null);
-  const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const [cameraAvailable, setCameraAvailable] = useState<boolean | null>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -123,7 +129,6 @@ export default function TaskSubmitScreen() {
   const onPickPhoto = useCallback(async () => {
     setSubmitError(null);
     setSubmitSuccessId(null);
-    setPhotoPath(null);
 
     const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!perm.granted) {
@@ -144,7 +149,6 @@ export default function TaskSubmitScreen() {
   const onTakePhoto = useCallback(async () => {
     setSubmitError(null);
     setSubmitSuccessId(null);
-    setPhotoPath(null);
 
     const perm = await ImagePicker.requestCameraPermissionsAsync();
     if (!perm.granted) {
@@ -172,7 +176,6 @@ export default function TaskSubmitScreen() {
 
   const onRemovePhoto = useCallback(() => {
     setPhotoAsset(null);
-    setPhotoPath(null);
   }, []);
 
   const onSubmit = useCallback(async () => {
@@ -183,29 +186,6 @@ export default function TaskSubmitScreen() {
 
     try {
       await saveTeamId(teamId);
-      let uploadedPath: string | null = photoPath;
-
-      if (photoAsset && !uploadedPath) {
-        setIsUploadingPhoto(true);
-        try {
-          const { path } = await uploadSubmissionPhoto({
-            asset: photoAsset,
-            teamId,
-            taskId,
-          });
-          uploadedPath = path;
-          setPhotoPath(path);
-        } catch (e) {
-          setSubmitError(
-            e instanceof Error
-              ? e.message
-              : 'Photo upload failed. Please try again.',
-          );
-          return;
-        } finally {
-          setIsUploadingPhoto(false);
-        }
-      }
 
       const fd = new FormData();
       fd.append('task_id', taskId);
@@ -215,8 +195,17 @@ export default function TaskSubmitScreen() {
         fd.append('text_answer', textAnswer);
       }
 
-      if (uploadedPath) {
-        fd.append('photo_path', uploadedPath);
+      if (photoAsset?.uri) {
+        // Prefer uploading via backend (works reliably in simulators and avoids direct Storage connectivity).
+        // FastAPI accepts this as UploadFile via the `photo` field.
+        const name =
+          photoAsset.fileName?.trim() ||
+          `submission-${taskId}-${Date.now()}.jpg`;
+        const type = photoAsset.mimeType?.trim() || 'image/jpeg';
+        fd.append(
+          'photo',
+          { uri: photoAsset.uri, name, type } as unknown as Blob,
+        );
       }
 
       const res = await fetch(apiUrl('/submissions/'), {
@@ -236,7 +225,15 @@ export default function TaskSubmitScreen() {
       }
 
       if (!res.ok) {
-        setSubmitError('Submission failed. Please try again.');
+        setSubmitError(
+          body && typeof body === 'object'
+            ? 'error' in body && typeof body.error === 'string' && body.error
+              ? body.error
+              : 'detail' in body && typeof body.detail === 'string' && body.detail
+                ? body.detail
+                : 'Submission failed. Please try again.'
+            : 'Submission failed. Please try again.',
+        );
         return;
       }
 
@@ -266,16 +263,34 @@ export default function TaskSubmitScreen() {
         e instanceof Error ? e.message : 'Submission failed. Please try again.',
       );
     } finally {
-      setIsUploadingPhoto(false);
       setIsSubmitting(false);
     }
-  }, [canSubmit, photoAsset, photoPath, taskId, teamId, textAnswer]);
+  }, [canSubmit, photoAsset, taskId, teamId, textAnswer]);
+
+  const onBackToTasks = useCallback(() => {
+    router.replace('/(tabs)/index');
+  }, []);
 
   return (
     <>
-      <Stack.Screen options={{ title: 'Submit', headerBackTitle: 'Tasks' }} />
+      <Stack.Screen
+        options={{
+          title: 'Submit',
+          headerBackTitle: 'Tasks',
+          headerLeft: () => (
+            <Pressable onPress={onBackToTasks} style={styles.headerBack}>
+              <Text style={[textStyles.defaultSemiBold, { color: tint }]}>
+                Back
+              </Text>
+            </Pressable>
+          ),
+        }}
+      />
       <View style={[screenStyles.container, { backgroundColor }]}>
-        <View style={styles.content}>
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+        >
           <Text style={[textStyles.title, { color: textColor }]}>
             Submission
           </Text>
@@ -439,8 +454,10 @@ export default function TaskSubmitScreen() {
                       styles.hint,
                       { color: textColor },
                     ]}
+                    numberOfLines={2}
+                    ellipsizeMode="middle"
                   >
-                    Selected: {photoAsset.fileName ?? photoAsset.uri}
+                    Selected: {displayAssetLabel(photoAsset)}
                   </Text>
                   <View style={styles.previewFrame}>
                     <Image
@@ -450,36 +467,6 @@ export default function TaskSubmitScreen() {
                       accessibilityLabel="Selected photo preview"
                     />
                   </View>
-                  {photoPath ? (
-                    <Text
-                      style={[
-                        textStyles.default,
-                        styles.hint,
-                        { color: textColor },
-                      ]}
-                    >
-                      Uploaded path:{' '}
-                      <Text
-                        style={[
-                          textStyles.defaultSemiBold,
-                          { color: textColor },
-                        ]}
-                      >
-                        {photoPath}
-                      </Text>
-                    </Text>
-                  ) : null}
-                  {isUploadingPhoto ? (
-                    <Text
-                      style={[
-                        textStyles.default,
-                        styles.hint,
-                        { color: textColor },
-                      ]}
-                    >
-                      Uploading photo…
-                    </Text>
-                  ) : null}
                 </>
               ) : (
                 <Text
@@ -531,15 +518,20 @@ export default function TaskSubmitScreen() {
               {isSubmitting ? 'Submitting…' : 'Submit'}
             </Text>
           </Pressable>
-        </View>
+        </ScrollView>
       </View>
     </>
   );
 }
 
 const styles = StyleSheet.create({
+  headerBack: {
+    paddingHorizontal: 6,
+    paddingVertical: 6,
+  },
   content: {
     gap: 8,
+    paddingBottom: 24,
   },
   taskHeader: {
     gap: 4,

--- a/backend/routes/submissions.py
+++ b/backend/routes/submissions.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPExcepti
 from pydantic import BaseModel
 from typing import Any, Dict, Optional
 
+from postgrest.exceptions import APIError
+
 from auth.organizer import require_organizer
 from services import get_supabase
 from services.scoring import score_submission
@@ -92,6 +94,17 @@ async def create_submission(
     photo_path: str = Form(None),
     photo: UploadFile = File(None),
 ):
+    # Validate ids early; PostgREST returns a 500 if we send non-UUID text into uuid columns.
+    try:
+        uuid.UUID(str(task_id))
+    except Exception:
+        raise HTTPException(status_code=400, detail="task_id must be a UUID")
+
+    try:
+        uuid.UUID(str(team_id))
+    except Exception:
+        raise HTTPException(status_code=400, detail="team_id must be a UUID")
+
     submission_id = str(uuid.uuid4())
     supabase = get_supabase()
 
@@ -143,7 +156,8 @@ async def create_submission(
                 lambda: supabase.storage.from_(storage_bucket()).upload(
                     stored_photo_path,
                     photo_bytes,
-                    file_options={"content-type": content_type, "upsert": True},
+                    # supabase-py passes these through to HTTP headers; values must be strings.
+                    file_options={"content-type": content_type, "upsert": "true"},
                 )
             )
         except Exception as e:
@@ -158,7 +172,11 @@ async def create_submission(
                 "rationale": f"Photo upload failed: {e}",
                 "ai_result": {"mode": "storage_upload", "error": str(e)},
             }
-            supabase.table("submissions").insert(submission).execute()
+            try:
+                supabase.table("submissions").insert(submission).execute()
+            except Exception:
+                # Don't mask the storage error with a DB insert failure.
+                pass
             return {"submission_id": submission_id, "status": "error"}
 
     submission = {
@@ -170,7 +188,16 @@ async def create_submission(
         "photo_url": stored_photo_path,
         "status": "pending"
     }
-    supabase.table("submissions").insert(submission).execute()
+    try:
+        supabase.table("submissions").insert(submission).execute()
+    except APIError as e:
+        # Convert common PostgREST errors into a client-friendly 4xx.
+        msg = ""
+        try:
+            msg = (e.args[0] or {}).get("message") or ""
+        except Exception:
+            msg = ""
+        raise HTTPException(status_code=400, detail=msg or "Invalid submission payload")
     
     background_tasks.add_task(score_submission, submission_id, task_id, team_id, normalized_text_answer, stored_photo_path, False)
     

--- a/backend/tests/test_submissions_routes.py
+++ b/backend/tests/test_submissions_routes.py
@@ -121,7 +121,8 @@ def app_and_client(monkeypatch):
 
     fake = _FakeSupabase()
     # Default: allow multiple to avoid the existing-submission branch.
-    fake.db["tasks"].append({"id": "task1", "allow_multiple_submissions": True})
+    task_id = "11111111-1111-1111-1111-111111111111"
+    fake.db["tasks"].append({"id": task_id, "allow_multiple_submissions": True})
 
     monkeypatch.setattr(submissions_routes, "get_supabase", lambda: fake)
     monkeypatch.setattr(submissions_routes, "score_submission", lambda *a, **kw: None)
@@ -133,6 +134,8 @@ def app_and_client(monkeypatch):
 
 def test_post_submission_photo_upload_path_format(app_and_client, monkeypatch):
     fake, client = app_and_client
+    task_id = "11111111-1111-1111-1111-111111111111"
+    team_id = "22222222-2222-2222-2222-222222222222"
 
     fixed_id = _uuid.UUID("00000000-0000-0000-0000-000000000123")
     from routes import submissions as submissions_routes
@@ -141,7 +144,7 @@ def test_post_submission_photo_upload_path_format(app_and_client, monkeypatch):
 
     resp = client.post(
         "/submissions/",
-        data={"task_id": "task1", "team_id": "teamA", "text_answer": ""},
+        data={"task_id": task_id, "team_id": team_id, "text_answer": ""},
         files={"photo": ("x.png", b"pngbytes", "image/png")},
     )
     assert resp.status_code == 200
@@ -151,7 +154,7 @@ def test_post_submission_photo_upload_path_format(app_and_client, monkeypatch):
 
     assert fake.upload_calls, "expected storage upload to be called"
     uploaded_path, uploaded_bytes, file_options = fake.upload_calls[0]
-    assert uploaded_path == f"teamA/task1/{fixed_id}.png"
+    assert uploaded_path == f"{team_id}/{task_id}/{fixed_id}.png"
     assert uploaded_bytes == b"pngbytes"
     assert file_options["content-type"] == "image/png"
 
@@ -164,6 +167,8 @@ def test_post_submission_photo_upload_path_format(app_and_client, monkeypatch):
 def test_post_submission_upload_failure_sets_error_status(app_and_client, monkeypatch):
     fake, client = app_and_client
     fake.fail_upload = True
+    task_id = "11111111-1111-1111-1111-111111111111"
+    team_id = "22222222-2222-2222-2222-222222222222"
 
     fixed_id = _uuid.UUID("00000000-0000-0000-0000-000000000999")
     from routes import submissions as submissions_routes
@@ -172,7 +177,7 @@ def test_post_submission_upload_failure_sets_error_status(app_and_client, monkey
 
     resp = client.post(
         "/submissions/",
-        data={"task_id": "task1", "team_id": "teamA", "text_answer": "hi"},
+        data={"task_id": task_id, "team_id": team_id, "text_answer": "hi"},
         files={"photo": ("x.jpg", b"jpgbytes", "image/jpeg")},
     )
     assert resp.status_code == 200
@@ -187,13 +192,15 @@ def test_post_submission_upload_failure_sets_error_status(app_and_client, monkey
 
 def test_get_submission_by_id_includes_signed_url_when_photo_exists(app_and_client):
     fake, client = app_and_client
+    task_id = "11111111-1111-1111-1111-111111111111"
+    team_id = "22222222-2222-2222-2222-222222222222"
     fake.db["submissions"].append(
         {
             "id": "sub1",
-            "task_id": "task1",
-            "team_id": "teamA",
+            "task_id": task_id,
+            "team_id": team_id,
             "text_answer": "",
-            "photo_url": "teamA/task1/sub1.png",
+            "photo_url": f"{team_id}/{task_id}/sub1.png",
             "status": "approved",
             "score": 3,
             "confidence": 0.95,
@@ -208,21 +215,23 @@ def test_get_submission_by_id_includes_signed_url_when_photo_exists(app_and_clie
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == "sub1"
-    assert data["photo_url"] == "teamA/task1/sub1.png"
+    assert data["photo_url"] == f"{team_id}/{task_id}/sub1.png"
     assert data["photo_signed_url"].startswith("https://signed.example/")
-    assert fake.sign_calls == [("teamA/task1/sub1.png", 600)]
+    assert fake.sign_calls == [(f"{team_id}/{task_id}/sub1.png", 600)]
 
 
 def test_list_submissions_omits_signed_urls(app_and_client):
     fake, client = app_and_client
+    task_id = "11111111-1111-1111-1111-111111111111"
+    team_id = "22222222-2222-2222-2222-222222222222"
     fake.db["submissions"].extend(
         [
             {
                 "id": "sub1",
-                "task_id": "task1",
-                "team_id": "teamA",
+                "task_id": task_id,
+                "team_id": team_id,
                 "text_answer": "",
-                "photo_url": "teamA/task1/sub1.png",
+                "photo_url": f"{team_id}/{task_id}/sub1.png",
                 "status": "approved",
                 "score": 3,
                 "confidence": 0.95,
@@ -234,7 +243,7 @@ def test_list_submissions_omits_signed_urls(app_and_client):
             {
                 "id": "sub2",
                 "task_id": "task2",
-                "team_id": "teamA",
+                "team_id": team_id,
                 "text_answer": "hi",
                 "photo_url": None,
                 "status": "pending",
@@ -248,7 +257,7 @@ def test_list_submissions_omits_signed_urls(app_and_client):
         ]
     )
 
-    resp = client.get("/submissions/?team_id=teamA")
+    resp = client.get(f"/submissions/?team_id={team_id}")
     assert resp.status_code == 200
     rows = resp.json()
     assert isinstance(rows, list)

--- a/components/app-error-boundary.tsx
+++ b/components/app-error-boundary.tsx
@@ -19,8 +19,10 @@ export function AppErrorBoundary({
         <AppErrorState
           error={toAppError(error)}
           onRetry={() => {
+            // Avoid double-reset loops:
+            // - `resetErrorBoundary()` triggers ErrorBoundary's `onReset`
+            // - calling `onResetToSafeRoute` here would fire it twice
             resetErrorBoundary();
-            onResetToSafeRoute?.();
           }}
           titleOverride="App error"
         />

--- a/components/app-error-state.tsx
+++ b/components/app-error-state.tsx
@@ -48,7 +48,7 @@ export function AppErrorState({
   const handleGoBack =
     onGoBack ?? (canGoBack ? () => router.back() : undefined);
   const primaryAction =
-    onRetry ?? handleGoBack ?? (() => router.replace('/(tabs)/index'));
+    onRetry ?? handleGoBack ?? (() => router.replace('/(tabs)'));
 
   const primaryLabel = onRetry ? 'Retry' : handleGoBack ? 'Go back' : 'Go home';
 

--- a/components/app-error-state.tsx
+++ b/components/app-error-state.tsx
@@ -48,7 +48,7 @@ export function AppErrorState({
   const handleGoBack =
     onGoBack ?? (canGoBack ? () => router.back() : undefined);
   const primaryAction =
-    onRetry ?? handleGoBack ?? (() => router.replace('/(tabs)'));
+    onRetry ?? handleGoBack ?? (() => router.replace('/(tabs)/index'));
 
   const primaryLabel = onRetry ? 'Retry' : handleGoBack ? 'Go back' : 'Go home';
 

--- a/components/ui/app-button.tsx
+++ b/components/ui/app-button.tsx
@@ -23,7 +23,11 @@ export function AppButton({
   labelStyle,
 }: AppButtonProps) {
   const mode: 'contained' | 'outlined' | 'text' =
-    tone === 'primary' ? 'contained' : tone === 'secondary' ? 'outlined' : 'text';
+    tone === 'primary'
+      ? 'contained'
+      : tone === 'secondary'
+        ? 'outlined'
+        : 'text';
 
   return (
     <Button
@@ -52,4 +56,3 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
 });
-

--- a/components/ui/app-button.tsx
+++ b/components/ui/app-button.tsx
@@ -1,0 +1,55 @@
+import { PropsWithChildren } from 'react';
+import { StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-native';
+import { Button } from 'react-native-paper';
+
+export type AppButtonTone = 'primary' | 'secondary' | 'ghost';
+
+type AppButtonProps = PropsWithChildren<{
+  tone?: AppButtonTone;
+  onPress?: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  style?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+}>;
+
+export function AppButton({
+  children,
+  tone = 'primary',
+  onPress,
+  disabled,
+  loading,
+  style,
+  labelStyle,
+}: AppButtonProps) {
+  const mode: 'contained' | 'outlined' | 'text' =
+    tone === 'primary' ? 'contained' : tone === 'secondary' ? 'outlined' : 'text';
+
+  return (
+    <Button
+      mode={mode}
+      onPress={onPress}
+      disabled={disabled}
+      loading={loading}
+      style={[styles.button, style]}
+      labelStyle={[styles.label, labelStyle]}
+      contentStyle={styles.content}
+    >
+      {children}
+    </Button>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: 999,
+  },
+  content: {
+    paddingVertical: 6,
+    paddingHorizontal: 6,
+  },
+  label: {
+    fontSize: 14,
+  },
+});
+

--- a/components/ui/app-card.tsx
+++ b/components/ui/app-card.tsx
@@ -1,0 +1,37 @@
+import { PropsWithChildren } from 'react';
+import { StyleProp, StyleSheet, ViewStyle } from 'react-native';
+import { Card } from 'react-native-paper';
+
+type AppCardProps = PropsWithChildren<{
+  onPress?: () => void;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<ViewStyle>;
+}>;
+
+export function AppCard({
+  children,
+  onPress,
+  disabled,
+  style,
+  contentStyle,
+}: AppCardProps) {
+  return (
+    <Card
+      mode="outlined"
+      onPress={onPress}
+      disabled={disabled}
+      style={[styles.card, style]}
+      contentStyle={contentStyle}
+    >
+      {children}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+  },
+});
+

--- a/components/ui/app-card.tsx
+++ b/components/ui/app-card.tsx
@@ -34,4 +34,3 @@ const styles = StyleSheet.create({
     borderRadius: 16,
   },
 });
-

--- a/components/ui/app-chip.tsx
+++ b/components/ui/app-chip.tsx
@@ -1,0 +1,60 @@
+import { StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-native';
+import { Chip, useTheme } from 'react-native-paper';
+
+export type AppChipTone = 'default' | 'accent' | 'success' | 'danger';
+
+type AppChipProps = {
+  children: string;
+  tone?: AppChipTone;
+  selected?: boolean;
+  compact?: boolean;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+};
+
+export function AppChip({
+  children,
+  tone = 'default',
+  selected = false,
+  compact = true,
+  style,
+  textStyle,
+}: AppChipProps) {
+  const theme = useTheme();
+  const mode: 'outlined' | 'flat' = selected ? 'flat' : 'outlined';
+
+  const toneColor =
+    tone === 'accent'
+      ? theme.colors.primary
+      : tone === 'success'
+        ? '#2E7D32'
+        : tone === 'danger'
+          ? '#C62828'
+          : theme.colors.onSurface;
+
+  const chipStyle: StyleProp<ViewStyle> = selected
+    ? { backgroundColor: toneColor, borderColor: toneColor }
+    : { borderColor: tone === 'default' ? theme.colors.outline : toneColor };
+
+  const chipTextStyle: StyleProp<TextStyle> = selected
+    ? { color: theme.colors.onPrimary }
+    : { color: tone === 'default' ? theme.colors.onSurface : toneColor };
+
+  return (
+    <Chip
+      mode={mode}
+      compact={compact}
+      style={[styles.chip, chipStyle, style]}
+      textStyle={[chipTextStyle, textStyle]}
+    >
+      {children}
+    </Chip>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    borderRadius: 999,
+  },
+});
+

--- a/components/ui/app-chip.tsx
+++ b/components/ui/app-chip.tsx
@@ -57,4 +57,3 @@ const styles = StyleSheet.create({
     borderRadius: 999,
   },
 });
-

--- a/components/ui/app-text.tsx
+++ b/components/ui/app-text.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren } from 'react';
+import { StyleProp, TextStyle } from 'react-native';
+import { Text } from 'react-native-paper';
+
+export type AppTextVariant = 'title' | 'subtitle' | 'body' | 'label';
+
+type AppTextProps = PropsWithChildren<{
+  variant?: AppTextVariant;
+  style?: StyleProp<TextStyle>;
+}>;
+
+export function AppText({ variant = 'body', style, children }: AppTextProps) {
+  const paperVariant =
+    variant === 'title'
+      ? 'headlineMedium'
+      : variant === 'subtitle'
+        ? 'titleLarge'
+        : variant === 'label'
+          ? 'labelLarge'
+          : 'bodyLarge';
+
+  return (
+    <Text variant={paperVariant} style={style}>
+      {children}
+    </Text>
+  );
+}
+

--- a/components/ui/app-text.tsx
+++ b/components/ui/app-text.tsx
@@ -25,4 +25,3 @@ export function AppText({ variant = 'body', style, children }: AppTextProps) {
     </Text>
   );
 }
-

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -3,4 +3,3 @@ export * from './app-card';
 export * from './app-chip';
 export * from './app-text';
 export * from './icon-symbol';
-

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,6 @@
+export * from './app-button';
+export * from './app-card';
+export * from './app-chip';
+export * from './app-text';
+export * from './icon-symbol';
+

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -36,16 +36,16 @@ export const Colors = {
 export const Fonts = Platform.select({
   ios: {
     // Loaded via expo-font in `app/_layout.tsx`
-    sans: 'JosefinSans_400Regular',
-    serif: 'JosefinSlab_400Regular',
+    sans: 'JosefinSans_600SemiBold',
+    serif: 'JosefinSlab_600SemiBold',
     /** iOS `UIFontDescriptorSystemDesignRounded` */
     rounded: 'ui-rounded',
     /** iOS `UIFontDescriptorSystemDesignMonospaced` */
     mono: 'ui-monospace',
   },
   default: {
-    sans: 'JosefinSans_400Regular',
-    serif: 'JosefinSlab_400Regular',
+    sans: 'JosefinSans_600SemiBold',
+    serif: 'JosefinSlab_600SemiBold',
     rounded: 'normal',
     mono: 'monospace',
   },

--- a/lib/team-session.ts
+++ b/lib/team-session.ts
@@ -1,0 +1,31 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const TEAM_ID_KEY = 'sapsut.teamId.v1';
+
+export async function getSavedTeamId(): Promise<string | null> {
+  try {
+    const v = await AsyncStorage.getItem(TEAM_ID_KEY);
+    const trimmed = (v ?? '').trim();
+    return trimmed ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveTeamId(teamId: string): Promise<void> {
+  const trimmed = (teamId ?? '').trim();
+  if (!trimmed) return;
+  try {
+    await AsyncStorage.setItem(TEAM_ID_KEY, trimmed);
+  } catch {
+    // Best-effort persistence; ignore.
+  }
+}
+
+export async function clearSavedTeamId(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TEAM_ID_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -36,17 +36,14 @@ export const textStyles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 24,
     fontFamily: Fonts?.sans,
-    fontWeight: '600',
   },
   title: {
     fontSize: 32,
     fontFamily: Fonts?.serif,
-    fontWeight: '600',
     lineHeight: 32,
   },
   subtitle: {
     fontSize: 20,
     fontFamily: Fonts?.serif,
-    fontWeight: '600',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo-google-fonts/josefin-sans": "^0.4.2",
         "@expo-google-fonts/josefin-slab": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -3306,6 +3307,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -8950,6 +8963,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9948,6 +9970,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-error-boundary": "^6.1.1",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-paper": "^5.15.1",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -1561,6 +1562,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
+      "integrity": "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -11540,6 +11563,51 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-paper": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.15.1.tgz",
+      "integrity": "sha512-qT3vtjWch7277JiyacOukPMmyJjgAeEXMZAl/1KdCFYGrarOVoVw5ElUcUCYwPdq9ReMyVZSX77Sr+7ELmSFEg==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.9",
+        "color": "^3.1.2",
+        "use-latest-callback": "^0.2.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
     },
     "node_modules/react-native-reanimated": {
       "version": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@expo-google-fonts/josefin-sans": "^0.4.2",
     "@expo-google-fonts/josefin-slab": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-error-boundary": "^6.1.1",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-paper": "^5.15.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "lib": ["DOM", "ESNext"],
+    "lib": [
+      "DOM",
+      "ESNext"
+    ],
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "noEmit": true,
@@ -14,7 +17,9 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -23,5 +28,6 @@
     ".expo/types/**/*.ts",
     "expo-env.d.ts",
     "types/**/*.d.ts"
-  ]
+  ],
+  "extends": "expo/tsconfig.base"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
+    "lib": ["DOM", "ESNext"],
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "noEmit": true,
@@ -17,9 +14,7 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [


### PR DESCRIPTION
# What
- Persist last-used Team ID on device and auto-fill it on the submission screen.
- Replace “UUID…” placeholder copy with friendlier text.
- Fix Tasks header/logo overlapping the status bar by applying safe-area top padding.
- Fix navigation/back labeling by routing back to /(tabs)/index and setting back title to Tasks.
- Make base typography feel bolder by defaulting to the 600 Josefin font faces.
- Add New / Completed indicators on task cards (Completed based on team submissions; New based on recent opens_at).
- Stabilize navigation to avoid "Unmatched Route" by routing organizer entry through a hidden tabs child, and adding safe redirects for `/` and unknown routes.
- Fix photo submission so it reliably uploads via backend multipart, keeps the Submit button reachable (scroll + truncation), and always provides a deterministic back path to Tasks.
- Update Tasks list to reflect submission status: completed tasks are disabled/greyed out, and in-review/pending routes to the confirmation screen (view-only).
- Prevent an error boundary retry loop that could trigger "Maximum update depth exceeded".
- Introduce React Native Paper + shared UI wrappers (`AppCard`, `AppChip`, `AppButton`, `AppText`) for consistent styling.

## Why
- Photo submissions were failing/sticking users on the submit screen, and long asset labels could push the primary action off-screen.
- Router state/organizer navigation could land on invalid paths and show "Unmatched Route".
- Completed/in-review tasks should not be editable; they should be disabled or view-only.
